### PR TITLE
убрал из зависимостей agp, иначе проникает в avito android test config

### DIFF
--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -16,8 +16,9 @@ dependencies {
     implementation(gradleApi())
     implementation(project(":kotlin-dsl-support"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
-    implementation("com.android.tools.build:gradle:$androidGradlePluginVersion")
     implementation("io.github.azagniotov:ant-style-path-matcher:$antPatternMatcherVersion")
+
+    compileOnly("com.android.tools.build:gradle:$androidGradlePluginVersion")
 
     testImplementation("com.google.truth:truth:$truthVersion")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlin2Version")


### PR DESCRIPTION
utils надо убивать срочно, как только стал публиковать с транзитивными зависимостями - зацепили весь клубок оттуда.

еще один пример почему нет оправдания наличию utils/common/etc модулям