### PR TITLE
fixed package name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ syncAndroidModules=true
 # Artifacts' versions
 # Scheme: year.month[.<version>]
 # Version is not a day of a month. We don't want to bound releases to days.
-projectVersion=2020.2.7
+projectVersion=2020.2.8
 # Previous stable version to be used in this project
 infraVersion=2020.2.7
 gradleVersion=6.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ syncAndroidModules=true
 # Artifacts' versions
 # Scheme: year.month[.<version>]
 # Version is not a day of a month. We don't want to bound releases to days.
-projectVersion=2020.2.8
+projectVersion=2020.2.7
 # Previous stable version to be used in this project
 infraVersion=2020.2.7
 gradleVersion=6.1.1

--- a/subprojects/gradle/design-screenshots/src/main/kotlin/com/avito/plugin/PullScreenshotsTask.kt
+++ b/subprojects/gradle/design-screenshots/src/main/kotlin/com/avito/plugin/PullScreenshotsTask.kt
@@ -23,7 +23,7 @@ open class PullScreenshotsTask : DefaultTask() {
 
     @TaskAction
     fun pullScreenshots() {
-        val applicationId = variant.get().applicationId
+        val applicationId = variant.get().testVariant.applicationId
         val adbDevicesManager = AdbDevicesManager(StdOutLogger())
         val adbDeviceHandler =  AdbDeviceHandlerLocal(ciLogger)
         val deviceSearch = DeviceSearchLocal(adbDevicesManager)


### PR DESCRIPTION
Pulling was broken, because I had to use testVariant.applicationId instead of just applicationId. Screenshots were requested from unexisting folder and that led pulling to fail