### PR TITLE
2020.2.9 released

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,9 @@ syncAndroidModules=true
 # Artifacts' versions
 # Scheme: year.month[.<version>]
 # Version is not a day of a month. We don't want to bound releases to days.
-projectVersion=2020.2.9
+projectVersion=2020.2.10
 # Previous stable version to be used in this project
-infraVersion=2020.2.8
+infraVersion=2020.2.9
 gradleVersion=6.2
 javaVersion=1.8
 # We use exact version to provide consistent environment and avoid build cache issues

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,12 @@ org.gradle.caching=true
 # https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures
 syncAndroidModules=true
 # Artifacts' versions
+# https://avito-tech.github.io/avito-android/docs/infrastructure/#versioning
 # Scheme: year.month[.<version>]
 # Version is not a day of a month. We don't want to bound releases to days.
-projectVersion=2020.2.10
-# Previous stable version to be used in this project
-infraVersion=2020.2.9
+projectVersion=2020.2.11
+# Current stable version to be used in this project
+infraVersion=2020.2.10
 gradleVersion=6.2
 javaVersion=1.8
 # We use exact version to provide consistent environment and avoid build cache issues

--- a/publish.sh
+++ b/publish.sh
@@ -2,4 +2,4 @@
 
 source $(dirname $0)/_main.sh
 
-runInBuilder "./gradlew publishRelease ${GRADLE_ARGS}"
+runInBuilder "./gradlew publishRelease ${GRADLE_ARGS} --no-parallel"


### PR DESCRIPTION
bump version in repo
use no-parallel to prevent 429 from bintray