### PR TITLE
MBS-7725 Collect build metrics from Teamcity for SLO

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,8 @@ kotsonVersion=2.5.0
 jslackVersion=3.4.1
 truthVersion=1.0
 jsonPathVersion=2.4.0
-teamcityRestClientVersion=1.6.1
+# https://github.com/JetBrains/teamcity-rest-client
+teamcityRestClientVersion=1.6.2
 androidGradlePluginVersion=3.5.3
 # Versions: https://r8.googlesource.com/r8/
 r8Version=1.6.58

--- a/subprojects/common/statsd/build.gradle.kts
+++ b/subprojects/common/statsd/build.gradle.kts
@@ -1,11 +1,15 @@
 plugins {
     id("kotlin")
     `maven-publish`
+    id("java-test-fixtures")
     id("com.jfrog.bintray")
 }
 
+val kotlinVersion: String by project
 val statsdVersion: String by project
 
 dependencies {
     implementation("com.timgroup:java-statsd-client:$statsdVersion")
+
+    testFixturesImplementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
 }

--- a/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSender.kt
+++ b/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSender.kt
@@ -50,7 +50,7 @@ interface StatsDSender {
         }
 
         private val errorHandler = StatsDClientErrorHandler {
-            logger.invoke("statsd", it)
+            logger.invoke("statsd error", it)
         }
     }
 }

--- a/subprojects/common/statsd/src/testFixtures/kotlin/com/avito/android/stats/FakeStatsDSender.kt
+++ b/subprojects/common/statsd/src/testFixtures/kotlin/com/avito/android/stats/FakeStatsDSender.kt
@@ -1,0 +1,14 @@
+package com.avito.android.stats
+
+import com.avito.android.stats.StatsDSender
+
+class FakeStatsdSender: StatsDSender {
+
+    val paths = mutableListOf<String>()
+    val metrics = mutableListOf<StatsMetric>()
+
+    override fun send(prefix: String, metric: StatsMetric) {
+        paths.add(prefix)
+        metrics.add(metric)
+    }
+}

--- a/subprojects/gradle/build-metrics/build.gradle.kts
+++ b/subprojects/gradle/build-metrics/build.gradle.kts
@@ -1,12 +1,15 @@
 plugins {
     id("kotlin")
     id("java-gradle-plugin")
+    id("java-test-fixtures")
     `maven-publish`
     id("com.jfrog.bintray")
 }
 
 val funktionaleVersion: String by project
 val androidGradlePluginVersion: String by project
+val mockitoKotlinVersion: String by project
+val mockitoJunit5Version: String by project
 
 dependencies {
     implementation(project(":subprojects:gradle:sentry-config"))
@@ -15,12 +18,16 @@ dependencies {
     implementation(project(":subprojects:gradle:logging"))
     implementation(project(":subprojects:gradle:kotlin-dsl-support"))
     implementation(project(":subprojects:gradle:impact-shared"))
+    implementation(project(":subprojects:gradle:teamcity"))
     implementation(project(":subprojects:gradle:trace-event"))
     implementation("org.funktionale:funktionale-try:$funktionaleVersion")
     implementation("com.android.tools.build:gradle:$androidGradlePluginVersion")
 
+    testImplementation("com.nhaarman:mockito-kotlin:$mockitoKotlinVersion")
+    testImplementation("org.mockito:mockito-junit-jupiter:$mockitoJunit5Version")
     testImplementation(project(":subprojects:gradle:git"))
     testImplementation(project(":subprojects:gradle:test-project"))
+    testImplementation(testFixtures(project(":subprojects:common:statsd")))
 }
 
 gradlePlugin {

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
@@ -4,6 +4,7 @@ import com.avito.android.gradle.profile.ProfileEventAdapter
 import com.avito.android.sentry.environmentInfo
 import com.avito.android.stats.statsd
 import com.avito.kotlin.dsl.getBooleanProperty
+import com.avito.kotlin.dsl.getMandatoryStringProperty
 import com.avito.kotlin.dsl.isRoot
 import com.avito.utils.gradle.BuildEnvironment
 import com.avito.utils.gradle.buildEnvironment
@@ -14,6 +15,7 @@ import org.gradle.internal.buildevents.BuildStartedTime
 import org.gradle.internal.logging.LoggingOutputInternal
 import org.gradle.internal.time.Clock
 import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.kotlin.dsl.register
 import java.io.File
 
 /**
@@ -34,7 +36,9 @@ open class BuildMetricsPlugin : Plugin<Project> {
             SentryConsumer(project),
             buildTraceConsumer(project)
         ))
-        project.tasks.register("collectTeamcityMetrics", CollectTeamcityMetricsTask::class.java)
+        project.tasks.register<CollectTeamcityMetricsTask>("collectTeamcityMetrics") {
+            buildId.set(project.getMandatoryStringProperty("avito.build.metrics.teamcityBuildId"))
+        }
     }
 
     private fun aggregatedConsumer(project: Project): MetricsConsumer {

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
@@ -5,6 +5,7 @@ import com.avito.android.sentry.environmentInfo
 import com.avito.android.stats.statsd
 import com.avito.kotlin.dsl.getBooleanProperty
 import com.avito.kotlin.dsl.getMandatoryStringProperty
+import com.avito.kotlin.dsl.getOptionalStringProperty
 import com.avito.kotlin.dsl.isRoot
 import com.avito.utils.gradle.BuildEnvironment
 import com.avito.utils.gradle.buildEnvironment
@@ -37,7 +38,7 @@ open class BuildMetricsPlugin : Plugin<Project> {
             buildTraceConsumer(project)
         ))
         project.tasks.register<CollectTeamcityMetricsTask>("collectTeamcityMetrics") {
-            buildId.set(project.getMandatoryStringProperty("avito.build.metrics.teamcityBuildId"))
+            buildId.set(project.getOptionalStringProperty("avito.build.metrics.teamcityBuildId"))
         }
     }
 

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
@@ -34,6 +34,7 @@ open class BuildMetricsPlugin : Plugin<Project> {
             SentryConsumer(project),
             buildTraceConsumer(project)
         ))
+        project.tasks.register("collectTeamcityMetrics", CollectTeamcityMetricsTask::class.java)
     }
 
     private fun aggregatedConsumer(project: Project): MetricsConsumer {

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsAction.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsAction.kt
@@ -1,0 +1,60 @@
+package com.avito.android.plugin.build_metrics
+
+import com.avito.android.plugin.build_metrics.CollectTeamcityMetricsAction.Parameters
+import com.avito.android.stats.StatsDConfig
+import com.avito.android.stats.StatsDSender
+import com.avito.android.stats.TimeMetric
+import com.avito.android.stats.graphiteSeries
+import com.avito.android.stats.graphiteSeriesElement
+import com.avito.teamcity.TeamcityApi
+import com.avito.teamcity.TeamcityCredentials
+import com.avito.utils.logging.CILogger
+import com.google.common.annotations.VisibleForTesting
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.jetbrains.teamcity.rest.Build
+import java.time.Duration
+
+@Suppress("UnstableApiUsage")
+abstract class CollectTeamcityMetricsAction : WorkAction<Parameters> {
+
+    interface Parameters : WorkParameters {
+        fun getBuildId(): Property<String>
+        fun getTeamcityCredentials(): Property<TeamcityCredentials>
+        fun getStatsdConfig(): Property<StatsDConfig>
+        fun getLogger(): Property<CILogger>
+    }
+
+    @VisibleForTesting
+    open val teamcity: TeamcityApi
+        get() = TeamcityApi.Impl(parameters.getTeamcityCredentials().get())
+
+    @VisibleForTesting
+    open val statsd: StatsDSender
+        get() = StatsDSender.Impl(parameters.getStatsdConfig().get()) { msg, _ ->
+            parameters.getLogger().get().info(msg)
+        }
+
+    override fun execute() {
+        val build = teamcity.getBuild(parameters.getBuildId().get())
+        sendMetric(build)
+    }
+
+    private fun sendMetric(build: Build) {
+        val buildId = graphiteSeriesElement(build.id.stringId)
+        val buildTypeId = graphiteSeries(build.buildConfigurationId.stringId)
+        val buildStatus = graphiteSeriesElement(build.status?.name ?: "unknown")
+        val duration = Duration.between(build.startDateTime, build.finishDateTime)
+
+        // we use a redundant structure only for compatibility reasons
+        val path = "ci.builds.teamcity.duration" +
+            ".build_type_id.${buildTypeId}" +
+            ".id.${buildId}" +
+            ".agent._" +
+            ".state._" +
+            ".status.${buildStatus}" +
+            "._._._._"
+        statsd.send(metric = TimeMetric(path, duration.toMillis()))
+    }
+}

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsAction.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsAction.kt
@@ -1,43 +1,22 @@
 package com.avito.android.plugin.build_metrics
 
-import com.avito.android.plugin.build_metrics.CollectTeamcityMetricsAction.Parameters
-import com.avito.android.stats.StatsDConfig
 import com.avito.android.stats.StatsDSender
 import com.avito.android.stats.TimeMetric
 import com.avito.android.stats.graphiteSeries
 import com.avito.android.stats.graphiteSeriesElement
 import com.avito.teamcity.TeamcityApi
-import com.avito.teamcity.TeamcityCredentials
-import com.avito.utils.logging.CILogger
-import com.google.common.annotations.VisibleForTesting
-import org.gradle.api.provider.Property
-import org.gradle.workers.WorkAction
-import org.gradle.workers.WorkParameters
 import org.jetbrains.teamcity.rest.Build
 import java.time.Duration
 
 @Suppress("UnstableApiUsage")
-abstract class CollectTeamcityMetricsAction : WorkAction<Parameters> {
+class CollectTeamcityMetricsAction(
+    val buildId: String,
+    private val teamcityApi: TeamcityApi,
+    private val statsd: StatsDSender
+) {
 
-    interface Parameters : WorkParameters {
-        fun getBuildId(): Property<String>
-        fun getTeamcityCredentials(): Property<TeamcityCredentials>
-        fun getStatsdConfig(): Property<StatsDConfig>
-        fun getLogger(): Property<CILogger>
-    }
-
-    @VisibleForTesting
-    open val teamcity: TeamcityApi
-        get() = TeamcityApi.Impl(parameters.getTeamcityCredentials().get())
-
-    @VisibleForTesting
-    open val statsd: StatsDSender
-        get() = StatsDSender.Impl(parameters.getStatsdConfig().get()) { msg, _ ->
-            parameters.getLogger().get().info(msg)
-        }
-
-    override fun execute() {
-        val build = teamcity.getBuild(parameters.getBuildId().get())
+    fun execute() {
+        val build = teamcityApi.getBuild(buildId)
         sendMetric(build)
     }
 

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsTask.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsTask.kt
@@ -1,0 +1,29 @@
+package com.avito.android.plugin.build_metrics
+
+import com.avito.android.stats.statsdConfig
+import com.avito.teamcity.teamcityCredentials
+import com.avito.utils.logging.ciLogger
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+abstract class CollectTeamcityMetricsTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor
+) : DefaultTask() {
+
+    @TaskAction
+    fun action() {
+        val buildId: String? = System.getenv("TMCT_METRICS_BUILD_ID")
+
+        require(!buildId.isNullOrBlank()) { "TMCT_METRICS_BUILD_ID env must be set" }
+
+        @Suppress("UnstableApiUsage")
+        workerExecutor.noIsolation().submit(CollectTeamcityMetricsAction::class.java) { parameters ->
+            parameters.getBuildId().set(buildId)
+            parameters.getLogger().set(project.ciLogger)
+            parameters.getStatsdConfig().set(project.statsdConfig)
+            parameters.getTeamcityCredentials().set(project.teamcityCredentials)
+        }
+    }
+}

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsTask.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsTask.kt
@@ -4,22 +4,27 @@ import com.avito.android.stats.statsdConfig
 import com.avito.teamcity.teamcityCredentials
 import com.avito.utils.logging.ciLogger
 import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.property
 import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
 
 abstract class CollectTeamcityMetricsTask @Inject constructor(
-    private val workerExecutor: WorkerExecutor
+    private val workerExecutor: WorkerExecutor,
+    objects: ObjectFactory
 ) : DefaultTask() {
+
+    @Input
+    val buildId = objects.property<String>()
 
     @TaskAction
     fun action() {
-        val buildId: String? = System.getenv("TMCT_METRICS_BUILD_ID")
-
-        require(!buildId.isNullOrBlank()) { "TMCT_METRICS_BUILD_ID env must be set" }
+        require(!buildId.orNull.isNullOrBlank()) { "teamcity buildId property must be set" }
 
         @Suppress("UnstableApiUsage")
-        workerExecutor.noIsolation().submit(CollectTeamcityMetricsAction::class.java) { parameters ->
+        workerExecutor.noIsolation().submit(CollectTeamcityMetricsWorkerAction::class.java) { parameters ->
             parameters.getBuildId().set(buildId)
             parameters.getLogger().set(project.ciLogger)
             parameters.getStatsdConfig().set(project.statsdConfig)

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsTask.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsTask.kt
@@ -21,8 +21,6 @@ abstract class CollectTeamcityMetricsTask @Inject constructor(
 
     @TaskAction
     fun action() {
-        require(!buildId.orNull.isNullOrBlank()) { "teamcity buildId property must be set" }
-
         @Suppress("UnstableApiUsage")
         workerExecutor.noIsolation().submit(CollectTeamcityMetricsWorkerAction::class.java) { parameters ->
             parameters.getBuildId().set(buildId)

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsWorkerAction.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsWorkerAction.kt
@@ -1,0 +1,36 @@
+package com.avito.android.plugin.build_metrics
+
+import com.avito.android.plugin.build_metrics.CollectTeamcityMetricsWorkerAction.Parameters
+import com.avito.android.stats.StatsDConfig
+import com.avito.android.stats.StatsDSender
+import com.avito.teamcity.TeamcityApi
+import com.avito.teamcity.TeamcityCredentials
+import com.avito.utils.logging.CILogger
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+@Suppress("UnstableApiUsage")
+abstract class CollectTeamcityMetricsWorkerAction : WorkAction<Parameters> {
+
+    interface Parameters : WorkParameters {
+        fun getBuildId(): Property<String>
+        fun getTeamcityCredentials(): Property<TeamcityCredentials>
+        fun getStatsdConfig(): Property<StatsDConfig>
+        fun getLogger(): Property<CILogger>
+    }
+
+    override fun execute() {
+        val logger = parameters.getLogger().get()
+        val statsd: StatsDSender = StatsDSender.Impl(parameters.getStatsdConfig().get()) { msg, _ ->
+            logger.info(msg)
+        }
+        val teamcity = TeamcityApi.Impl(parameters.getTeamcityCredentials().get())
+        val action = CollectTeamcityMetricsAction(
+            buildId = parameters.getBuildId().get(),
+            teamcityApi = teamcity,
+            statsd = statsd
+        )
+        action.execute()
+    }
+}

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsWorkerAction.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsWorkerAction.kt
@@ -21,6 +21,7 @@ abstract class CollectTeamcityMetricsWorkerAction : WorkAction<Parameters> {
     }
 
     override fun execute() {
+        require(!parameters.getBuildId().orNull.isNullOrBlank()) { "teamcity buildId property must be set" }
         val logger = parameters.getLogger().get()
         val statsd: StatsDSender = StatsDSender.Impl(parameters.getStatsdConfig().get()) { msg, _ ->
             logger.info(msg)

--- a/subprojects/gradle/build-metrics/src/test/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsActionTest.kt
+++ b/subprojects/gradle/build-metrics/src/test/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsActionTest.kt
@@ -1,0 +1,79 @@
+package com.avito.android.plugin.build_metrics
+
+import com.avito.android.stats.FakeStatsdSender
+import com.avito.android.stats.StatsDConfig
+import com.avito.teamcity.TeamcityApi
+import com.avito.teamcity.TeamcityCredentials
+import com.avito.utils.logging.CILogger
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.gradle.api.internal.provider.DefaultProperty
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.Property
+import org.jetbrains.teamcity.rest.Build
+import org.jetbrains.teamcity.rest.BuildConfigurationId
+import org.jetbrains.teamcity.rest.BuildId
+import org.jetbrains.teamcity.rest.BuildState
+import org.jetbrains.teamcity.rest.BuildStatus
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.Month
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+@Suppress("UnstableApiUsage")
+class CollectTeamcityMetricsActionTest {
+
+    @Test
+    fun `send build metric`() {
+        val teamcity: TeamcityApi = mock()
+        val statsd = FakeStatsdSender()
+
+        val build: Build = mock()
+        whenever(build.id).thenReturn(BuildId(buildId))
+        val startDate = ZonedDateTime.of(
+            LocalDateTime.of(2020, Month.JANUARY, 1, 0, 0),
+            ZoneId.systemDefault()
+        )
+        val endDate = startDate.plusSeconds(90)
+        whenever(build.buildConfigurationId).thenReturn(BuildConfigurationId("BUILD_TYPE"))
+        whenever(build.state).thenReturn(BuildState.FINISHED)
+        whenever(build.status).thenReturn(BuildStatus.SUCCESS)
+        whenever(build.startDateTime).thenReturn(startDate)
+        whenever(build.finishDateTime).thenReturn(endDate)
+
+        whenever(teamcity.getBuild(buildId)).thenReturn(build)
+
+        val action = object : CollectTeamcityMetricsAction() {
+
+            override val teamcity = teamcity
+            override val statsd = statsd
+
+            override fun getParameters() = object : Parameters {
+                override fun getBuildId() = property(buildId)
+                override fun getTeamcityCredentials() = property(mock<TeamcityCredentials>())
+                override fun getStatsdConfig() = property(mock<StatsDConfig>())
+                override fun getLogger() = property(CILogger.allToStdout)
+            }
+        }
+        action.execute()
+
+        assertWithMessage("Send a metric about one build")
+            .that(statsd.metrics).hasSize(1)
+
+        assertThat(statsd.paths.first()).isEmpty()
+        val metric = statsd.metrics.first()
+        assertThat(metric.path).isEqualTo(
+            "ci.builds.teamcity.duration.build_type_id.BUILD_TYPE.id.BUILD_ID.agent._.state._.status.SUCCESS._._._._"
+        )
+        assertThat(metric.value).isEqualTo(90_000)
+    }
+
+    private val buildId = "BUILD_ID"
+
+}
+
+private inline fun <reified T : Any> property(value: T): Property<T> =
+    DefaultProperty(T::class.java).value(Providers.of(value))

--- a/subprojects/gradle/build-metrics/src/test/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsActionTest.kt
+++ b/subprojects/gradle/build-metrics/src/test/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsActionTest.kt
@@ -1,17 +1,11 @@
 package com.avito.android.plugin.build_metrics
 
 import com.avito.android.stats.FakeStatsdSender
-import com.avito.android.stats.StatsDConfig
 import com.avito.teamcity.TeamcityApi
-import com.avito.teamcity.TeamcityCredentials
-import com.avito.utils.logging.CILogger
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
-import org.gradle.api.internal.provider.DefaultProperty
-import org.gradle.api.internal.provider.Providers
-import org.gradle.api.provider.Property
 import org.jetbrains.teamcity.rest.Build
 import org.jetbrains.teamcity.rest.BuildConfigurationId
 import org.jetbrains.teamcity.rest.BuildId
@@ -46,18 +40,7 @@ class CollectTeamcityMetricsActionTest {
 
         whenever(teamcity.getBuild(buildId)).thenReturn(build)
 
-        val action = object : CollectTeamcityMetricsAction() {
-
-            override val teamcity = teamcity
-            override val statsd = statsd
-
-            override fun getParameters() = object : Parameters {
-                override fun getBuildId() = property(buildId)
-                override fun getTeamcityCredentials() = property(mock<TeamcityCredentials>())
-                override fun getStatsdConfig() = property(mock<StatsDConfig>())
-                override fun getLogger() = property(CILogger.allToStdout)
-            }
-        }
+        val action = CollectTeamcityMetricsAction(buildId, teamcity, statsd)
         action.execute()
 
         assertWithMessage("Send a metric about one build")
@@ -74,6 +57,3 @@ class CollectTeamcityMetricsActionTest {
     private val buildId = "BUILD_ID"
 
 }
-
-private inline fun <reified T : Any> property(value: T): Property<T> =
-    DefaultProperty(T::class.java).value(Providers.of(value))

--- a/subprojects/gradle/teamcity/build.gradle.kts
+++ b/subprojects/gradle/teamcity/build.gradle.kts
@@ -7,10 +7,11 @@ plugins {
 val teamcityRestClientVersion: String by project
 
 dependencies {
+    api("org.jetbrains.teamcity:teamcity-rest-client:$teamcityRestClientVersion")
+
     implementation(gradleApi())
     implementation(project(":subprojects:gradle:kotlin-dsl-support"))
     implementation(project(":subprojects:gradle:utils"))
-    implementation("org.jetbrains.teamcity:teamcity-rest-client:$teamcityRestClientVersion")
 
     testImplementation(project(":subprojects:gradle:test-project"))
 }

--- a/subprojects/gradle/teamcity/src/main/kotlin/com/avito/teamcity/TeamcityApi.kt
+++ b/subprojects/gradle/teamcity/src/main/kotlin/com/avito/teamcity/TeamcityApi.kt
@@ -51,6 +51,9 @@ interface TeamcityApi {
         onlySuccess: Boolean = false
     ): Sequence<String>
 
+    fun getBuild(buildId: String): Build
+
+    @Deprecated("Use getBuild instead")
     fun getBuildNumber(buildId: String): String?
 
     fun getPreviousBuildOnCommit(
@@ -152,6 +155,8 @@ interface TeamcityApi {
             onlySuccess: Boolean
         ): Sequence<String> =
             getLastBuilds(buildType, commit, branchSpec, limit, onlySuccess).map { build -> build.id.stringId }
+
+        override fun getBuild(buildId: String): Build = teamCityInstance.build(BuildId(buildId))
 
         override fun getBuildNumber(buildId: String): String? = teamCityInstance.build(BuildId(buildId)).buildNumber
 

--- a/subprojects/gradle/teamcity/src/main/kotlin/com/avito/teamcity/TeamcityCredentials.kt
+++ b/subprojects/gradle/teamcity/src/main/kotlin/com/avito/teamcity/TeamcityCredentials.kt
@@ -10,11 +10,17 @@ interface TeamcityCredentials : Serializable {
     val user: String
     val password: String
 
-    class Impl(project: Project) : TeamcityCredentials,
-        Serializable {
-        override val url: String by lazy { project.getMandatoryStringProperty("teamcityUrl") }
-        override val user: String by lazy { project.getMandatoryStringProperty("teamcityApiUser") }
-        override val password: String by lazy { project.getMandatoryStringProperty("teamcityApiPassword") }
+    class Impl(
+        override val url: String,
+        override val user: String,
+        override val password: String
+    ) : TeamcityCredentials, Serializable {
+
+        constructor(project: Project) : this(
+            project.getMandatoryStringProperty("teamcityUrl"),
+            project.getMandatoryStringProperty("teamcityApiUser"),
+            project.getMandatoryStringProperty("teamcityApiPassword")
+        )
     }
 }
 


### PR DESCRIPTION
Now we can collect build metrics from Teamcity.

Why can't we collect all metrics from the inside? 
There is an overhead before Gradle. Also, we can't handle hardly failed builds

`./gradlew collectTeamcityMetrics`