### PR TITLE
prepare to fix empty string property default behaviour

### DIFF
--- a/subprojects/gradle/kotlin-dsl-support/src/main/kotlin/com/avito/kotlin/dsl/ProjectExtensions.kt
+++ b/subprojects/gradle/kotlin-dsl-support/src/main/kotlin/com/avito/kotlin/dsl/ProjectExtensions.kt
@@ -25,9 +25,22 @@ fun Project.getOptionalStringProperty(name: String, default: String, defaultIfBl
 /**
  * @param allowBlank todo false by default
  */
-fun Project.getMandatoryStringProperty(name: String, allowBlank: Boolean = true): String =
-    getOptionalStringProperty(name, nullIfBlank = !allowBlank)
-        ?: throw RuntimeException("Parameter: $name is required (must be not empty)")
+fun Project.getMandatoryStringProperty(name: String, allowBlank: Boolean = true): String {
+    return if (hasProperty(name)) {
+        val string = property(name)?.toString()
+        if (string.isNullOrBlank()) {
+            if (allowBlank) {
+                ""
+            } else {
+                throw RuntimeException("Parameter: $name is blank but required")
+            }
+        } else {
+            string
+        }
+    } else {
+        throw RuntimeException("Parameter: $name is missing but required")
+    }
+}
 
 fun Project.getOptionalIntProperty(name: String): Int? =
     try {

--- a/subprojects/gradle/kotlin-dsl-support/src/main/kotlin/com/avito/kotlin/dsl/ProjectExtensions.kt
+++ b/subprojects/gradle/kotlin-dsl-support/src/main/kotlin/com/avito/kotlin/dsl/ProjectExtensions.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KProperty
 //TODO these methods should return Property<X>
 
 /**
- * @param nullIfBlank there may be cases when it's ok to pass empty string to override
+ * @param nullIfBlank we accept cases when user passes empty string to override
  * todo true by default, false to not break anything that rely on previous behavior
  */
 fun Project.getOptionalStringProperty(name: String, nullIfBlank: Boolean = false): String? =

--- a/subprojects/gradle/kotlin-dsl-support/src/test/kotlin/com/avito/kotlin/dsl/GetMandatoryStringPropertyTest.kt
+++ b/subprojects/gradle/kotlin-dsl-support/src/test/kotlin/com/avito/kotlin/dsl/GetMandatoryStringPropertyTest.kt
@@ -1,0 +1,56 @@
+package com.avito.kotlin.dsl
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class GetMandatoryStringPropertyTest {
+
+    @Test
+    fun `getMandatoryStringProperty - throws exception - on empty string if not allowed`() {
+        val project = ProjectBuilder.builder().build()
+        project.extensions.extraProperties["someProperty"] = ""
+
+        assertThrows<RuntimeException> {
+            project.getMandatoryStringProperty("someProperty", allowBlank = false)
+        }
+    }
+
+    //todo throw by default
+    @Test
+    fun `getMandatoryStringProperty - returns empty value - on empty string value by default`() {
+        val project = ProjectBuilder.builder().build()
+        project.extensions.extraProperties["someProperty"] = ""
+
+        val value = project.getMandatoryStringProperty("someProperty", allowBlank = true)
+        assertThat(value).isEqualTo("")
+    }
+
+    @Test
+    fun `getMandatoryStringProperty - returns empty value - on empty string if allowed`() {
+        val project = ProjectBuilder.builder().build()
+        project.extensions.extraProperties["someProperty"] = ""
+
+        val value = project.getMandatoryStringProperty("someProperty", allowBlank = true)
+        assertThat(value).isEqualTo("")
+    }
+
+    @Test
+    fun `getMandatoryStringProperty - throws exception - on no property`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertThrows<RuntimeException> {
+            project.getMandatoryStringProperty("someProperty")
+        }
+    }
+
+    @Test
+    fun `getMandatoryStringProperty - returns correct value`() {
+        val project = ProjectBuilder.builder().build()
+        project.extensions.extraProperties["someProperty"] = "12345"
+
+        val value = project.getMandatoryStringProperty("someProperty")
+        assertThat(value).isEqualTo("12345")
+    }
+}

--- a/subprojects/gradle/kotlin-dsl-support/src/test/kotlin/com/avito/kotlin/dsl/GetOptionalStringPropertyTest.kt
+++ b/subprojects/gradle/kotlin-dsl-support/src/test/kotlin/com/avito/kotlin/dsl/GetOptionalStringPropertyTest.kt
@@ -1,0 +1,60 @@
+package com.avito.kotlin.dsl
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+internal class GetOptionalStringPropertyTest {
+
+    //todo null by default
+    @Test
+    fun `getOptionalStringProperty - returns empty string - on empty string by default`() {
+        val project = ProjectBuilder.builder().build()
+        project.extensions.extraProperties["someProperty"] = ""
+
+        val value = project.getOptionalStringProperty("someProperty")
+        assertThat(value).isEqualTo("")
+    }
+
+    @Test
+    fun `getOptionalStringProperty - returns null - on no property`() {
+        val project = ProjectBuilder.builder().build()
+
+        val value = project.getOptionalStringProperty("someProperty")
+        assertThat(value).isNull()
+    }
+
+    @Test
+    fun `getOptionalStringProperty - returns correct value`() {
+        val project = ProjectBuilder.builder().build()
+        project.extensions.extraProperties["someProperty"] = "12345"
+
+        val value = project.getOptionalStringProperty("someProperty")
+        assertThat(value).isEqualTo("12345")
+    }
+
+    @Test
+    fun `getOptionalStringProperty - returns default - on no value by default`() {
+        val project = ProjectBuilder.builder().build()
+
+        val value = project.getOptionalStringProperty("someProperty", default = "4321")
+        assertThat(value).isEqualTo("4321")
+    }
+
+    @Test
+    fun `getOptionalStringProperty - returns default - on no value with defaultIfBlank=false`() {
+        val project = ProjectBuilder.builder().build()
+
+        val value = project.getOptionalStringProperty("someProperty", default = "4321", defaultIfBlank = false)
+        assertThat(value).isEqualTo("4321")
+    }
+
+    @Test
+    fun `getOptionalStringProperty - returns empty string instead of default - on empty value with defaultIfBlank=false`() {
+        val project = ProjectBuilder.builder().build()
+        project.extensions.extraProperties["someProperty"] = ""
+
+        val value = project.getOptionalStringProperty("someProperty", default = "4321", defaultIfBlank = false)
+        assertThat(value).isEqualTo("")
+    }
+}


### PR DESCRIPTION
empty string value is a valid for getMandatoryStringProperty
and don't trigger default value usage in getOptionalStringProperty be default

it's about to change for more consistent behavior;
it will be done in two stages, first one in this PR,
calls in avito scripts will specify allowBlank/nullIfBlank explicitly
and then we'll change default behavior: empty string will be read as missing value