### PR TITLE
MBS-7596 Auto merge PR when ready

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,8 @@
+pull_request_rules:
+    - name: Automatically merge PR
+      conditions:
+          - base=develop
+          - label="merge when ready"
+      actions:
+          merge:
+              method: squash


### PR DESCRIPTION
## Automatically merge PR when "ready"

- All branch protection rules are passed
- PR has a label `merge when ready`

## TODO

- [x] approve from the security team

## These decisions have been made

- Use [Mergify bot](https://github.com/marketplace/mergify): popular, verified by GitHub, free for Open Source projects, has more than enough features.
How it looks: https://github.com/eugene-krivobokov/automerge-playground/pull/9
See *Checks* tab.

- Don't rely on the title to avoid mistakes. The label is easier to select and filter by.
- Don't merge by default to avoid accidental merges. This decision must be made explicitly by the author.
- Use Mergify bot only for auto-merge and keep as simple logic as possible.
For WIP I've chosen simpler and faster bot: [WIP](https://github.com/marketplace/wip)

![](https://marketplace-screenshots.githubusercontent.com/1362/d2915f80-d6b4-11e8-8892-88e61164a6a6?auto=webp&format=jpeg&width=670)