### PR TITLE
MBS-8048 fix test running on a clean emulator

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -68,6 +68,7 @@ object Dependencies {
 
     object androidTest {
         val runner = "androidx.test:runner:${Versions.androidXTest}"
+        val orchestrator = "androidx.test:orchestrator:${Versions.androidXTest}"
         val ddmlib = "com.android.tools.ddms:ddmlib:26.2.0"
         val uiAutomator = "androidx.test.uiautomator:uiautomator:2.2.0"
         val core = "androidx.test:core:${Versions.androidXTest}"

--- a/subprojects/android-test/test-app/build.gradle.kts
+++ b/subprojects/android-test/test-app/build.gradle.kts
@@ -90,6 +90,9 @@ dependencies {
     androidTestImplementation(project(":subprojects:common:okhttp"))
     androidTestImplementation(project(":subprojects:common:time"))
 
+    androidTestImplementation(Dependencies.androidTest.runner)
+    androidTestUtil(Dependencies.androidTest.orchestrator)
+
     androidTestImplementation(Dependencies.test.junit)
     androidTestImplementation(Dependencies.okhttp)
     androidTestImplementation(Dependencies.okhttpLogging)


### PR DESCRIPTION
**Problem**
Tests do not run from Android Studio on a clean emulator. Orchestrator isn't being installed. AS shows error `Test running failed: No test results`.

**Steps to reproduce**
1. Remove orchestrator from the emulator: `adb uninstall androidx.test.orchestrator`;
1. Run any test from `test-app` using Android Studio;
1. Error `Test running failed: No test results` occurred.