### PR TITLE
MBS-8041 Refresh expired OpenID token

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -38,9 +38,11 @@ object Dependencies {
     val rxJava = "io.reactivex:rxjava:1.3.8"
     val statsd = "com.timgroup:java-statsd-client:3.1.0"
 
-    // we don't use an official client https://github.com/kubernetes-client/java because fabric8 one has much better api,
-    // support all features we need and actively maintained
+    // We use this client due to better API
+    // It supports all features we need and actively maintained
     val kubernetesClient = "io.fabric8:kubernetes-client:4.9.0"
+    // We use the official kubernetes client only for missing features
+    val officialKubernetesClient = "io.kubernetes:client-java:8.0.0"
     val kubernetesDsl = "com.fkorotkov:kubernetes-dsl:2.7.1"
     val dexlib = "org.smali:dexlib2:2.3"
     val commonsText = "org.apache.commons:commons-text:1.6"

--- a/subprojects/gradle/kubernetes/build.gradle.kts
+++ b/subprojects/gradle/kubernetes/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     api(project(":subprojects:gradle:kotlin-dsl-support"))
 
     implementation(gradleApi())
+    implementation(Dependencies.officialKubernetesClient)
 }

--- a/subprojects/gradle/kubernetes/src/main/kotlin/com/avito/utils/gradle/KubernetesCredentials.kt
+++ b/subprojects/gradle/kubernetes/src/main/kotlin/com/avito/utils/gradle/KubernetesCredentials.kt
@@ -20,6 +20,7 @@ sealed class KubernetesCredentials : Serializable {
     ) : KubernetesCredentials(), Serializable
 }
 
+// TODO: get rid of this default. autoConfig is enabled by default
 private val kubeConfigDefaultPath: String by lazy {
     val userHome: String = requireUserHome()
     "${userHome}/.kube/config"


### PR DESCRIPTION
We support Open Id tokens in k8s for authentication and authorization. 
`kubectl` refreshes tokens automatically and stores changes to kube config file.

[Kubernetes - OpenID Connect Tokens](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens)

How they look in the config:

```yaml
users:
- name: username
  user:
    as-user-extra: {}
    auth-provider:
      config:
        client-id: k8s
        client-secret: xxx
        extra-scopes: groups
        id-token: xxx                       <-------
        idp-issuer-url: https://xxx
        refresh-token: xxx
      name: oidc
```

`id-token` is the  [Open id token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) in Jwt format:

```json
{
 "iss":"https://xxx",
 "sub":"xxx",
 "aud":"k8s",
 "exp":1585929826,  <---
 "iat":000,
 "at_hash":"xxx",
 "email":"user@mail",
  
```
 `exp` - is the expiration date. This is how the client knows it in advance.

Unfortunately, fabric8 kubernetes-client doesn't refresh tokens.
I've reused implementation from the official client (https://github.com/kubernetes-client/java/pull/871)

Known issues:
- The client persists yaml correctly but with another formatting style. I think we can live with it for now.