### PR TITLE
PROPOSAL MBS-5428 Add dependency analyzer plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") apply false
     id("com.android.application") apply false
     id("com.jfrog.bintray") version "1.8.4" apply false
+    id("com.autonomousapps.dependency-analysis")
 }
 
 val artifactoryUrl: String? by project
@@ -46,6 +47,10 @@ val publishReleaseTaskName = "publishRelease"
 
 val finalProjectVersion: String = System.getProperty("avito.project.version").let { env ->
     if (env.isNullOrBlank()) projectVersion else env
+}
+
+dependencyAnalysis {
+    chatty(false)
 }
 
 subprojects {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -139,6 +139,7 @@ pluginManagement {
                 includeGroup("com.jfrog.bintray")
                 includeGroup("com.slack.keeper")
                 includeGroup("nebula.integtest")
+                includeGroup("com.autonomousapps.dependency-analysis")
             }
         }
         exclusiveContent {
@@ -181,6 +182,8 @@ pluginManagement {
 
                 pluginId == "com.slack.keeper" ->
                     useModule("com.slack.keeper:keeper:0.4.3")
+                pluginId == "com.autonomousapps.dependency-analysis" ->
+                    useVersion("0.38.0")
             }
         }
     }

--- a/subprojects/android-test/test-inhouse-runner/build.gradle.kts
+++ b/subprojects/android-test/test-inhouse-runner/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 
 dependencies {
     api(project(":subprojects:android-test:test-instrumentation-runner"))
+    api(project(":subprojects:android-test:junit-utils"))
+    api(project(":subprojects:android-test:test-report"))
     implementation(project(":subprojects:common:sentry"))
     implementation(project(":subprojects:common:okhttp"))
     implementation(project(":subprojects:common:statsd"))


### PR DESCRIPTION
Plugin to analyze dependencies https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin
It can:
- Report incorrect dependency level i.e. we use implementation but need api
- Report unused dependencies
- Report needed transitive dependencies
In the future, we can enable it on CI when we can trust him.