### PR TITLE
MBS-7688 Don't wrap retry error in custom exception

### DIFF
--- a/subprojects/android-test/test-app/src/androidTest/kotlin/com/avito/android/ui/test/OverflowMenuTest.kt
+++ b/subprojects/android-test/test-app/src/androidTest/kotlin/com/avito/android/ui/test/OverflowMenuTest.kt
@@ -1,19 +1,17 @@
 package com.avito.android.ui.test
 
 import android.view.MenuItem
-import com.avito.android.runner.UITestFrameworkException
+import androidx.test.espresso.NoMatchingRootException
 import com.avito.android.ui.OverflowMenuActivity
+import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
+import ru.avito.util.assertThrows
 
 class OverflowMenuTest {
 
     @get:Rule
     val rule = screenRule<OverflowMenuActivity>()
-
-    @get:Rule
-    val exception: ExpectedException = ExpectedException.none()
 
     @Test
     fun menuItem_isClickable_inActionMenu() {
@@ -42,9 +40,9 @@ class OverflowMenuTest {
             )
         )
 
-        exception.expect(UITestFrameworkException::class.java)
-        exception.expectMessage("Не найдена view в иерархии")
-
-        Screen.overflow.toolbar.menuItem.withDisabledAutoOpenOverflow().actions.click()
+        val error = assertThrows<NoMatchingRootException> {
+            Screen.overflow.toolbar.menuItem.withDisabledAutoOpenOverflow().actions.click()
+        }
+        assertThat(error).hasMessageThat().contains("Не найдена view в иерархии")
     }
 }

--- a/subprojects/android-test/test-app/src/androidTest/kotlin/com/avito/android/ui/test/retry/RetryTest.kt
+++ b/subprojects/android-test/test-app/src/androidTest/kotlin/com/avito/android/ui/test/retry/RetryTest.kt
@@ -6,27 +6,20 @@ import com.avito.android.ui.test.Screen
 import com.avito.android.ui.test.screenRule
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
-import ru.avito.util.instanceOf
-import java.lang.RuntimeException
+import ru.avito.util.assertThrows
 
 class RetryTest {
 
     @get:Rule
     val rule = screenRule<RetryActivity>(launchActivity = true)
 
-    @get:Rule
-    val exception: ExpectedException = ExpectedException.none()
-
     @Test
     fun failWithOriginalError_oneShotActionFailedWithUnexpectedError() {
         // We must preserve an original error for a user
         // It can get lost accidentally due to UITestConfig.waiterAllowedExceptions
-        exception.expectCause(instanceOf<UnexpectedFatalError>())
-
-        Screen.retry.button.firstFail(UnexpectedFatalError()).click()
-
-        Screen.retry.buttonClickIndicator.checks.isDisplayed()
+        assertThrows<UnexpectedFatalError> {
+            Screen.retry.button.firstFail(UnexpectedFatalError()).click()
+        }
     }
 
     @Test

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.annotation.CallSuper
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.base.DefaultFailureHandler
 import androidx.test.platform.app.InstrumentationRegistry
 import com.avito.android.mock.MockDispatcher
 import com.avito.android.monitoring.CompositeTestIssuesMonitor
@@ -16,6 +17,7 @@ import com.avito.android.test.UITestConfig
 import com.avito.android.test.interceptor.HumanReadableActionInterceptor
 import com.avito.android.test.interceptor.HumanReadableAssertionInterceptor
 import com.avito.android.test.report.Report
+import com.avito.android.test.report.ReportFriendlyFailureHandler
 import com.avito.android.test.report.ReportImplementation
 import com.avito.android.test.report.ReportProvider
 import com.avito.android.test.report.ReportTestListener
@@ -196,7 +198,9 @@ abstract class InHouseInstrumentationTestRunner :
         super.onCreate(arguments)
 
         testRunEnvironment.executeIfRealRun {
-            Espresso.setFailureHandler(ReportFriendlyFailureHandler(targetContext))
+            Espresso.setFailureHandler(
+                ReportFriendlyFailureHandler(DefaultFailureHandler(targetContext))
+            )
             initUITestConfig()
 
             DeviceSettingsChecker(targetContext).check()


### PR DESCRIPTION
The original error: https://github.com/avito-tech/avito-android/pull/175/files#r379403828
I've missed a couple of exceptions in that attempt.

- [x] fastCheck is ok without handling `UITestFrameworkException`
- [x] fastCheck is ok in compatibility mode