### PR TITLE
MBS-8112 make ci steps plugin kotlin dsl compatible

### DIFF
--- a/docs/content/docs/projects/CiSteps.md
+++ b/docs/content/docs/projects/CiSteps.md
@@ -30,18 +30,35 @@ The plugin can be applied to a root project or any module.
 
 First of all, name your chain:
 
-```groovy
+{{< tabs "chain" >}}
+{{< tab "Kotlin" >}}
+```kotlin
 builds {
-    myChain {
-       ...
+    register("myChain") {
+ 
+       //optional description for generated task
+       taskDescription.set("This chain does something useful")
     }
 }
 ```
+{{< /tab >}}
+{{< tab "Groovy" >}}
+```groovy
+builds {
+    myChain {
+
+       //optional description for generated task
+       taskDescription.set("This chain does something useful")
+    }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Avito example chains
 
 - `localCheck` - compilation checks for local run
-- `fastCheck` - as fast as possible checks for Pull Request. It must conform [CI agreement]({{< ref "/docs/ci/CIValues.md" >}})
+- `prCheck` - as fast as possible checks for Pull Request. It must conform [CI agreement]({{< ref "/docs/ci/CIValues.md" >}})
 - `fullCheck` - as full as possible checks to be run after merges, non-blocking, could be slow
 - `release` - chain to release our app
 
@@ -49,15 +66,38 @@ builds {
 
 Step is a declaration to run some logic. It works inside a chain:
 
-```groovy
+{{< tabs "steps" >}}
+{{< tab "Kotlin" >}}
+```kotlin
 build {
-    fastCheck { // <--- chain
+    register("prCheck") { // <--- chain
+
         unitTests {} // <--- step
         uiTests {}
         lint {}
+
+        //optional description for generated task
+        taskDescription.set("This chain does something useful")
     }
 }
 ```
+{{< /tab >}}
+{{< tab "Groovy" >}}
+```groovy
+build {
+    fastCheck { // <--- chain
+
+        unitTests {} // <--- step
+        uiTests {}
+        lint {}
+
+        //optional description for generated task
+        taskDescription.set("This chain does something useful")
+    }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 Now when you invoke `./gradlew fastCheck` gradle will run unitTests, uiTests and lint of corresponding project
 
@@ -67,6 +107,19 @@ Now when you invoke `./gradlew fastCheck` gradle will run unitTests, uiTests and
 
 Runs instrumentation tests.
 
+{{< tabs "ui tests" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+uiTests {
+  configurations("configurationName") // list of instrumentation configuration to depends on
+  sendStatistics = false // by default
+  suppressFailures = false // by default
+  useImpactAnalysis = false // by default
+  suppressFlaky = false // by default. [игнорирование падений FlakyTest]({{< ref "/docs/test/FlakyTests.md" >}}).
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 uiTests {
   configurations = ["configurationName"] // list of instrumentation configuration to depends on
@@ -76,41 +129,82 @@ uiTests {
   suppressFlaky = false // by default. [игнорирование падений FlakyTest]({{< ref "/docs/test/FlakyTests.md" >}}).
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Performance tests
 
 Runs performance tests.
 
+{{< tabs "performance tests" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+performanceTests {
+  configuration("configuration name") // performance configuration from Instrumentation plugin
+  enabled = true // true by default
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 performanceTests {
   configuration = "configuration name" // performance configuration from Instrumentation plugin
   enabled = true // true by default
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Android lint
 
 Run [Android lint]({{< ref "/docs/checks/AndroidLint.md" >}}) tasks.
 
+{{< tabs "lint" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+lint {}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 lint {}
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Compile UI tests
 
 Compile instrumentation tests. It is helpful in local development.
 
+{{< tabs "compile ui tests" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+compileUiTests {}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 compileUiTests {}
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Unit tests
 
 Run unit tests.
 
+{{< tabs "unit tests" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+unitTests {}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 unitTests {}
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Upload to QApps
 
@@ -118,6 +212,18 @@ unitTests {}
 
 Upload [artifacts]({{< relref "#collecting-artifacts">}}) to QApps (internal system)
 
+{{< tabs "upload to qapps" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+artifacts {
+    apk("debugApk", ...)
+}
+uploadToQapps {
+    artifacts = setOf("debugApk")
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 artifacts {
     apk("debugApk", ...)
@@ -126,11 +232,25 @@ uploadToQapps {
     artifacts = ["debugApk"]
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Upload to Artifactory
 
 Upload [artifacts]({{< relref "#collecting-artifacts">}}) to Artifactory.
 
+{{< tabs "upload to artifactory" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+artifacts {
+    file("myReport", "${project.buildDir}/reports/my_report.json")
+}
+uploadToArtifactory {
+    artifacts = setOf("myReport")
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 artifacts {
     file("myReport", "${project.buildDir}/reports/my_report.json")
@@ -139,6 +259,8 @@ uploadToArtifactory {
     artifacts = ["myReport"]
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Upload to Prosector
 
@@ -146,6 +268,18 @@ uploadToArtifactory {
 
 Upload [artifacts]({{< relref "#collecting-artifacts">}}) to [Prosector (internal)](http://links.k.avito.ru/cfxrREPBQ).
 
+{{< tabs "upload to prosector" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+artifacts {
+    apk("debugApk", ...)
+}
+uploadToProsector {
+    artifacts = setOf("debugApk")
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 artifacts {
     apk("debugApk", ...)
@@ -154,6 +288,8 @@ uploadToProsector {
     artifacts = ["debugApk"]
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Upload build results
 
@@ -161,11 +297,22 @@ uploadToProsector {
 
 Upload all build results to a deploy service.
 
+{{< tabs "upload build result" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+uploadBuildResult {
+    uiTestConfiguration = "regression" // instrumentation configuration
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 uploadBuildResult {
     uiTestConfiguration = "regression" // instrumentation configuration
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Deploy to Google Play
 
@@ -173,9 +320,18 @@ uploadBuildResult {
 
 Deploy to Google play.
 
+{{< tabs "deploy to google play" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+deploy {}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 deploy {}
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Configuration checks
 
@@ -183,14 +339,34 @@ deploy {}
 
 Checks a repository configuration. See `:build-script-test` for details.
 
-```groovy
-    configuration {}
+{{< tabs "config checks" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+configuration {}
 ```
+{{< /tab >}}
+{{< tab "Groovy" >}}
+```groovy
+configuration {}
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Using impact analysis in step
 
 Step could use [Impact analysis]({{< ref "/docs/ci/ImpactAnalysis.md" >}}). It is disabled by default.
 
+{{< tabs "use impact analysis" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+fastCheck {
+    uiTests {
+        useImpactAnalysis = true
+    }
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 fastCheck {
     uiTests {
@@ -198,11 +374,30 @@ fastCheck {
     }
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Suppressing errors in step
 
 In different scenarios steps could fail whole build, some can be configured not to.
 
+{{< tabs "suppressing errors" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+fastCheck {
+    uiTests { 
+        suppressFailures = false 
+    }
+}
+
+release {
+    uiTests { 
+        suppressFailures = true 
+    }
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 fastCheck {
     uiTests { 
@@ -216,16 +411,29 @@ release {
     }
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Collecting artifacts
 
 Artifacts that planned to be used(uploaded somewhere) must be registered:
 
+{{< tabs "collecting artifacts" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+artifacts {
+   file("lintReport", "${project.buildDir}/reports/lint-results-release.html")
+}
+```
+{{< /tab >}}
+{{< tab "Groovy" >}}
 ```groovy
 artifacts {
    file("lintReport", "${project.buildDir}/reports/lint-results-release.html")
 }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 There are different types of artifacts:
 
@@ -234,14 +442,34 @@ There are different types of artifacts:
 - mapping - gets r8 mapping by buildType and checks availability
 - file - gets any file by path and checks availability
 
-```groovy
+{{< tabs "different types of artifacts" >}}
+{{< tab "Kotlin" >}}
+```kotlin
+import com.avito.cd.BuildVariant.RELEASE
+
+val releaseSha1 = "my sha" // it's public info, so safe to share
+
 artifacts {
-   apk("releaseApk", RELEASE, "com.avito.android", apkPath("release")) { signature = releaseSha1 }
-   bundle("releaseBundle", RELEASE, "com.avito.android", bundlePath("release")) { signature = releaseSha1 }
+   apk("releaseApk", RELEASE, "com.avito.android", "${project.buildDir}/outputs/apk/release/avito.apk") { signature = releaseSha1 }
+   bundle("releaseBundle", RELEASE, "com.avito.android", "${project.buildDir}/outputs/bundle/release/avito.aab") { signature = releaseSha1 }
    mapping("releaseMapping", RELEASE, "${project.buildDir}/outputs/mapping/release/mapping.txt")
    file("featureTogglesJson", "${project.buildDir}/reports/feature_toggles.json")
 }
 ```
+{{< /tab >}}
+{{< tab "Groovy" >}}
+```groovy
+def releaseSha1 = "my sha" // it's public info, so safe to share
+
+artifacts {
+   apk("releaseApk", RELEASE, "com.avito.android", "${project.buildDir}/outputs/apk/release/avito.apk") { signature = releaseSha1 }
+   bundle("releaseBundle", RELEASE, "com.avito.android", "${project.buildDir}/outputs/bundle/release/avito.aab") { signature = releaseSha1 }
+   mapping("releaseMapping", RELEASE, "${project.buildDir}/outputs/mapping/release/mapping.txt")
+   file("featureTogglesJson", "${project.buildDir}/reports/feature_toggles.json")
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 The first argument is a key for upload steps.
 

--- a/docs/content/docs/projects/CiSteps.md
+++ b/docs/content/docs/projects/CiSteps.md
@@ -32,6 +32,7 @@ First of all, name your chain:
 
 {{< tabs "chain" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 builds {
     register("myChain") {
@@ -41,8 +42,10 @@ builds {
     }
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 builds {
     myChain {
@@ -52,6 +55,7 @@ builds {
     }
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -68,6 +72,7 @@ Step is a declaration to run some logic. It works inside a chain:
 
 {{< tabs "steps" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 build {
     register("prCheck") { // <--- chain
@@ -81,8 +86,10 @@ build {
     }
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 build {
     fastCheck { // <--- chain
@@ -96,6 +103,7 @@ build {
     }
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -109,6 +117,7 @@ Runs instrumentation tests.
 
 {{< tabs "ui tests" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 uiTests {
   configurations("configurationName") // list of instrumentation configuration to depends on
@@ -118,8 +127,10 @@ uiTests {
   suppressFlaky = false // by default. [игнорирование падений FlakyTest]({{< ref "/docs/test/FlakyTests.md" >}}).
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 uiTests {
   configurations = ["configurationName"] // list of instrumentation configuration to depends on
@@ -129,6 +140,7 @@ uiTests {
   suppressFlaky = false // by default. [игнорирование падений FlakyTest]({{< ref "/docs/test/FlakyTests.md" >}}).
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -138,20 +150,24 @@ Runs performance tests.
 
 {{< tabs "performance tests" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 performanceTests {
   configuration("configuration name") // performance configuration from Instrumentation plugin
   enabled = true // true by default
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 performanceTests {
   configuration = "configuration name" // performance configuration from Instrumentation plugin
   enabled = true // true by default
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -161,14 +177,18 @@ Run [Android lint]({{< ref "/docs/checks/AndroidLint.md" >}}) tasks.
 
 {{< tabs "lint" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 lint {}
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 lint {}
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -178,14 +198,18 @@ Compile instrumentation tests. It is helpful in local development.
 
 {{< tabs "compile ui tests" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 compileUiTests {}
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 compileUiTests {}
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -195,14 +219,18 @@ Run unit tests.
 
 {{< tabs "unit tests" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 unitTests {}
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 unitTests {}
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -214,6 +242,7 @@ Upload [artifacts]({{< relref "#collecting-artifacts">}}) to QApps (internal sys
 
 {{< tabs "upload to qapps" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 artifacts {
     apk("debugApk", ...)
@@ -222,8 +251,10 @@ uploadToQapps {
     artifacts = setOf("debugApk")
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 artifacts {
     apk("debugApk", ...)
@@ -232,6 +263,7 @@ uploadToQapps {
     artifacts = ["debugApk"]
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -241,6 +273,7 @@ Upload [artifacts]({{< relref "#collecting-artifacts">}}) to Artifactory.
 
 {{< tabs "upload to artifactory" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 artifacts {
     file("myReport", "${project.buildDir}/reports/my_report.json")
@@ -249,8 +282,10 @@ uploadToArtifactory {
     artifacts = setOf("myReport")
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 artifacts {
     file("myReport", "${project.buildDir}/reports/my_report.json")
@@ -259,6 +294,7 @@ uploadToArtifactory {
     artifacts = ["myReport"]
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -270,6 +306,7 @@ Upload [artifacts]({{< relref "#collecting-artifacts">}}) to [Prosector (interna
 
 {{< tabs "upload to prosector" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 artifacts {
     apk("debugApk", ...)
@@ -278,8 +315,10 @@ uploadToProsector {
     artifacts = setOf("debugApk")
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 artifacts {
     apk("debugApk", ...)
@@ -288,6 +327,7 @@ uploadToProsector {
     artifacts = ["debugApk"]
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -299,18 +339,22 @@ Upload all build results to a deploy service.
 
 {{< tabs "upload build result" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 uploadBuildResult {
     uiTestConfiguration = "regression" // instrumentation configuration
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 uploadBuildResult {
     uiTestConfiguration = "regression" // instrumentation configuration
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -322,14 +366,18 @@ Deploy to Google play.
 
 {{< tabs "deploy to google play" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 deploy {}
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 deploy {}
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -341,14 +389,18 @@ Checks a repository configuration. See `:build-script-test` for details.
 
 {{< tabs "config checks" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 configuration {}
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 configuration {}
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -358,6 +410,7 @@ Step could use [Impact analysis]({{< ref "/docs/ci/ImpactAnalysis.md" >}}). It i
 
 {{< tabs "use impact analysis" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 fastCheck {
     uiTests {
@@ -365,8 +418,10 @@ fastCheck {
     }
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 fastCheck {
     uiTests {
@@ -374,6 +429,7 @@ fastCheck {
     }
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -383,6 +439,7 @@ In different scenarios steps could fail whole build, some can be configured not 
 
 {{< tabs "suppressing errors" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 fastCheck {
     uiTests { 
@@ -396,8 +453,10 @@ release {
     }
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 fastCheck {
     uiTests { 
@@ -411,6 +470,7 @@ release {
     }
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -420,18 +480,22 @@ Artifacts that planned to be used(uploaded somewhere) must be registered:
 
 {{< tabs "collecting artifacts" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 artifacts {
    file("lintReport", "${project.buildDir}/reports/lint-results-release.html")
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 artifacts {
    file("lintReport", "${project.buildDir}/reports/lint-results-release.html")
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -444,6 +508,7 @@ There are different types of artifacts:
 
 {{< tabs "different types of artifacts" >}}
 {{< tab "Kotlin" >}}
+
 ```kotlin
 import com.avito.cd.BuildVariant.RELEASE
 
@@ -456,8 +521,10 @@ artifacts {
    file("featureTogglesJson", "${project.buildDir}/reports/feature_toggles.json")
 }
 ```
+
 {{< /tab >}}
 {{< tab "Groovy" >}}
+
 ```groovy
 def releaseSha1 = "my sha" // it's public info, so safe to share
 
@@ -468,6 +535,7 @@ artifacts {
    file("featureTogglesJson", "${project.buildDir}/reports/feature_toggles.json")
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/BuildStepListExtension.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/BuildStepListExtension.kt
@@ -16,6 +16,7 @@ import com.avito.ci.steps.UploadToProsector
 import com.avito.ci.steps.UploadToQapps
 import com.avito.ci.steps.VerifyArtifactsStep
 import groovy.lang.Closure
+import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.kotlin.dsl.property
@@ -35,44 +36,88 @@ open class BuildStepListExtension(internal val name: String, objects: ObjectFact
         configureAndAdd(ConfigurationCheck(name), closure)
     }
 
+    fun configuration(action: Action<ConfigurationCheck>) {
+        configureAndAdd(ConfigurationCheck(name), action)
+    }
+
     fun uiTests(closure: Closure<UiTestCheck>) {
         configureAndAdd(UiTestCheck(name), closure)
+    }
+
+    fun uiTests(action: Action<UiTestCheck>) {
+        configureAndAdd(UiTestCheck(name), action)
     }
 
     fun performanceTests(closure: Closure<PerformanceTestCheck>) {
         configureAndAdd(PerformanceTestCheck(name), closure)
     }
 
+    fun performanceTests(action: Action<PerformanceTestCheck>) {
+        configureAndAdd(PerformanceTestCheck(name), action)
+    }
+
     fun compileUiTests(closure: Closure<CompileUiTests>) {
         configureAndAdd(CompileUiTests(name), closure)
+    }
+
+    fun compileUiTests(action: Action<CompileUiTests>) {
+        configureAndAdd(CompileUiTests(name), action)
     }
 
     fun unitTests(closure: Closure<UnitTestCheck>) {
         configureAndAdd(UnitTestCheck(name), closure)
     }
 
+    fun unitTests(action: Action<UnitTestCheck>) {
+        configureAndAdd(UnitTestCheck(name), action)
+    }
+
     fun lint(closure: Closure<LintCheck>) {
         configureAndAdd(LintCheck(name), closure)
+    }
+
+    fun lint(action: Action<LintCheck>) {
+        configureAndAdd(LintCheck(name), action)
     }
 
     fun uploadToQapps(closure: Closure<UploadToQapps>) {
         configureAndAdd(UploadToQapps(name, artifactsConfig), closure)
     }
 
+    fun uploadToQapps(action: Action<UploadToQapps>) {
+        configureAndAdd(UploadToQapps(name, artifactsConfig), action)
+    }
+
     fun uploadToArtifactory(closure: Closure<UploadToArtifactory>) {
         configureAndAdd(UploadToArtifactory(name, artifactsConfig), closure)
+    }
+
+    fun uploadToArtifactory(action: Action<UploadToArtifactory>) {
+        configureAndAdd(UploadToArtifactory(name, artifactsConfig), action)
     }
 
     fun uploadToProsector(closure: Closure<UploadToProsector>) {
         configureAndAdd(UploadToProsector(name, artifactsConfig), closure)
     }
 
+    fun uploadToProsector(action: Action<UploadToProsector>) {
+        configureAndAdd(UploadToProsector(name, artifactsConfig), action)
+    }
+
     fun uploadBuildResult(closure: Closure<UploadBuildResult>) {
         configureAndAdd(UploadBuildResult(name), closure)
     }
 
+    fun uploadBuildResult(action: Action<UploadBuildResult>) {
+        configureAndAdd(UploadBuildResult(name), action)
+    }
+
     fun deploy(closure: Closure<DeployStep>) {
         configureAndAdd(DeployStep(name, artifactsConfig), closure)
+    }
+
+    fun deploy(action: Action<DeployStep>) {
+        configureAndAdd(DeployStep(name, artifactsConfig), action)
     }
 
     fun artifacts(closure: Closure<ArtifactsConfiguration>) {
@@ -86,10 +131,27 @@ open class BuildStepListExtension(internal val name: String, objects: ObjectFact
         step.useImpactAnalysis = this.useImpactAnalysis
     }
 
+    fun artifacts(action: Action<ArtifactsConfiguration>) {
+        val step = VerifyArtifactsStep(name, artifactsConfig)
+        steps.add(step)
+
+        action.execute(artifactsConfig)
+
+        step.useImpactAnalysis = this.useImpactAnalysis
+    }
+
     private fun <T : BuildStep> configureAndAdd(step: T, configure: Closure<T>) {
         configure.delegate = step
         configure.resolveStrategy = Closure.DELEGATE_FIRST
         configure.call()
+        if (step is ImpactAnalysisAwareBuildStep) {
+            step.useImpactAnalysis = this.useImpactAnalysis
+        }
+        steps.add(step)
+    }
+
+    private fun <T : BuildStep> configureAndAdd(step: T, action: Action<T>) {
+        action.execute(step)
         if (step is ImpactAnalysisAwareBuildStep) {
             step.useImpactAnalysis = this.useImpactAnalysis
         }

--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/BuildStepListExtension.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/BuildStepListExtension.kt
@@ -26,11 +26,12 @@ open class BuildStepListExtension(internal val name: String, objects: ObjectFact
 
     private val artifactsConfig = ArtifactsConfiguration()
 
-    internal val description = objects.property<String>()
-
     internal val steps: ListProperty<BuildStep> = objects.listProperty(BuildStep::class.java).empty()
 
-    internal var useImpactAnalysis: Boolean = false
+    //todo property
+    var useImpactAnalysis: Boolean = false
+
+    val taskDescription = objects.property<String>()
 
     fun configuration(closure: Closure<ConfigurationCheck>) {
         configureAndAdd(ConfigurationCheck(name), closure)

--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/CiStepsPlugin.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/CiStepsPlugin.kt
@@ -26,7 +26,7 @@ class CiStepsPlugin : Plugin<Project> {
 
             val task = project.tasks.register<Task>(buildTask.name) {
                 group = taskGroup
-                description = buildTask.description.orNull
+                description = buildTask.taskDescription.orNull
             }
 
             project.gradle.projectsEvaluated {

--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/ArtifactsConfiguration.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/ArtifactsConfiguration.kt
@@ -2,6 +2,7 @@ package com.avito.ci.steps
 
 import com.avito.cd.BuildVariant
 import groovy.lang.Closure
+import org.gradle.api.Action
 
 open class ArtifactsConfiguration {
 
@@ -40,6 +41,22 @@ open class ArtifactsConfiguration {
         closure.call()
     }
 
+    fun apk(
+        id: String,
+        variant: BuildVariant,
+        packageName: String,
+        path: String,
+        action: Action<Output.ApkOutput>
+    ) {
+        check(path.endsWith(".apk")) {
+            "$path is incorrect apk file. Specify full path to .apk file"
+        }
+        val apk = Output.ApkOutput(variant, packageName, path)
+        registerOutput(id, apk)
+
+        action.execute(apk)
+    }
+
     fun bundle(
         id: String,
         variant: BuildVariant,
@@ -55,6 +72,22 @@ open class ArtifactsConfiguration {
 
         closure.delegate = bundle
         closure.call()
+    }
+
+    fun bundle(
+        id: String,
+        variant: BuildVariant,
+        packageName: String,
+        path: String,
+        action: Action<Output.BundleOutput>
+    ) {
+        check(path.endsWith(".aab")) {
+            "$path is incorrect aab file. Specify full path to .aab file"
+        }
+        val bundle = Output.BundleOutput(variant, packageName, path)
+        registerOutput(id, bundle)
+
+        action.execute(bundle)
     }
 
     fun copy(): ArtifactsConfiguration {

--- a/subprojects/gradle/cd/src/test/kotlin/com/avito/ci/CiStepsDynamicTest.kt
+++ b/subprojects/gradle/cd/src/test/kotlin/com/avito/ci/CiStepsDynamicTest.kt
@@ -11,6 +11,28 @@ import java.io.File
 internal class CiStepsDynamicTest {
 
     @Test
+    fun `cd plugin - custom task created - kotlin dsl`(@TempDir projectDir: File) {
+        projectDir.file(
+            name = "build.gradle.kts",
+            content = """
+            plugins {
+                id("com.avito.android.cd")
+            }
+            
+            builds {
+                register("myCustomTask") {
+                    taskDescription.set("My customTask description")
+                }
+            }
+        """.trimIndent()
+        )
+
+        gradlew(projectDir, "tasks", "-Pci=true").assertThat()
+            .buildSuccessful()
+            .outputContains("myCustomTask - My customTask description")
+    }
+
+    @Test
     fun `cd plugin - custom task created`(@TempDir projectDir: File) {
         projectDir.file(
             name = "build.gradle",
@@ -21,7 +43,7 @@ internal class CiStepsDynamicTest {
             
             builds {
                 myCustomTask {
-                    description.set("My customTask description")
+                    taskDescription.set("My customTask description")
                 }
             }
         """.trimIndent()
@@ -60,7 +82,7 @@ internal class CiStepsDynamicTest {
             buildGradleExtra = """
             builds {
                 myCustomTask {
-                    description.set("My customTask description from root project")
+                    taskDescription.set("My customTask description from root project")
                 }
             }    
             """.trimIndent(),
@@ -71,7 +93,7 @@ internal class CiStepsDynamicTest {
                     buildGradleExtra = """
                     builds {
                         myCustomTask {
-                            description.set("My customTask description from inner project")
+                            taskDescription.set("My customTask description from inner project")
                         }
                     }       
                     """.trimIndent()


### PR DESCRIPTION
Have some problems with "recommended approach": using `org.gradle.api.Action<T>` interface

Looks like this is my problem: https://docs.gradle.org/current/userguide/custom_gradle_types.html#dsl_support_and_extensibility

> When Gradle creates an instance of a custom type, it decorates the instance to mix-in DSL and extensibility support.
Each decorated instance implements ExtensionAware, and so can have extension objects attached to it.
Note that plugins and the elements of containers created using Project.container() are currently not decorated, due to backwards compatibility issues.

I had to create copy with `Action<T>` of each method with `Closure` and so far this configures OK inside `build.gradle.kts`
```
plugins {
    id("com.avito.android.cd")
}

builds {
    register("someChain") {
        uiTests {
            configurations("regress")
        }
    }
}
```