### PR TITLE
MBS-8348 Ignore unknown CD config deployments

### DIFF
--- a/subprojects/gradle/upload-cd-build-result/build.gradle.kts
+++ b/subprojects/gradle/upload-cd-build-result/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     testImplementation(project(":subprojects:gradle:test-project"))
     testImplementation(project(":subprojects:common:test-okhttp"))
     testImplementation(project(":subprojects:gradle:git-test-fixtures"))
+    testImplementation(project(":subprojects:gradle:logging-test-fixtures"))
 }

--- a/subprojects/gradle/upload-cd-build-result/src/main/kotlin/com/avito/cd/CdBuildConfig.kt
+++ b/subprojects/gradle/upload-cd-build-result/src/main/kotlin/com/avito/cd/CdBuildConfig.kt
@@ -44,6 +44,8 @@ data class CdBuildConfig(
             val track: Track
         ) : Deployment()
 
+        data class Unknown(val type: String): Deployment()
+
         enum class Track {
             @SerializedName("alpha")
             ALPHA,

--- a/subprojects/gradle/upload-cd-build-result/src/main/kotlin/com/avito/cd/CdBuildConfigValidator.kt
+++ b/subprojects/gradle/upload-cd-build-result/src/main/kotlin/com/avito/cd/CdBuildConfigValidator.kt
@@ -1,0 +1,30 @@
+package com.avito.cd
+
+import com.avito.utils.logging.CILogger
+
+internal class CdBuildConfigValidator(
+    private val config: CdBuildConfig,
+    private val logger: CILogger
+) {
+
+    fun validate() {
+        warnAboutUnsupportedDeployments()
+        checkUniqueGooglePlayDeployments()
+    }
+
+    private fun warnAboutUnsupportedDeployments() {
+        config.deployments.filterIsInstance<CdBuildConfig.Deployment.Unknown>().forEach {
+            logger.info("Ignore unknown CD config deployment: ${it.type}")
+        }
+    }
+
+    private fun checkUniqueGooglePlayDeployments() {
+        val googlePlayDeployments = config.deployments.filterIsInstance<CdBuildConfig.Deployment.GooglePlay>()
+        val deploysByVariant = googlePlayDeployments.groupBy(CdBuildConfig.Deployment.GooglePlay::buildVariant)
+        deploysByVariant.forEach { (_, deploys) ->
+            require(deploys.size == 1) {
+                "Must be one deploy per variant, but was: $googlePlayDeployments"
+            }
+        }
+    }
+}

--- a/subprojects/gradle/upload-cd-build-result/src/main/kotlin/com/avito/cd/DeploymentDeserializer.kt
+++ b/subprojects/gradle/upload-cd-build-result/src/main/kotlin/com/avito/cd/DeploymentDeserializer.kt
@@ -12,7 +12,7 @@ internal object DeploymentDeserializer : JsonDeserializer<CdBuildConfig.Deployme
             "google-play" -> {
                 context.deserialize<CdBuildConfig.Deployment.GooglePlay>(json, CdBuildConfig.Deployment.GooglePlay::class.java)
             }
-            else -> throw IllegalArgumentException("Value of field \"type\":$type incorrect")
+            else -> CdBuildConfig.Deployment.Unknown(type)
         }
     }
 }

--- a/subprojects/gradle/upload-cd-build-result/src/main/kotlin/com/avito/cd/ProjectExtentions.kt
+++ b/subprojects/gradle/upload-cd-build-result/src/main/kotlin/com/avito/cd/ProjectExtentions.kt
@@ -5,6 +5,7 @@ import com.avito.kotlin.dsl.ProjectProperty
 import com.avito.kotlin.dsl.getOptionalStringProperty
 import com.avito.utils.gradle.BuildEnvironment
 import com.avito.utils.gradle.buildEnvironment
+import com.avito.utils.logging.ciLogger
 import org.gradle.api.Project
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.Provider
@@ -23,7 +24,7 @@ private class CdBuildConfigFactory : (Project) -> Provider<CdBuildConfig> {
                 Providers.of(configFilePath).map { path ->
                     val configFile = project.rootProject.file(path)
                     val config = deserializeToCdBuildConfig(configFile)
-                    validate(config)
+                    CdBuildConfigValidator(config, project.ciLogger).validate()
                     config
                 }
             } else {
@@ -38,16 +39,6 @@ private class CdBuildConfigFactory : (Project) -> Provider<CdBuildConfig> {
     private fun deserializeToCdBuildConfig(configFile: File): CdBuildConfig {
         require(configFile.exists()) { "Can't find cd config file in $configFile" }
         return gson.fromJson<CdBuildConfig>(configFile.reader(), CdBuildConfig::class.java)
-    }
-
-    private fun validate(config: CdBuildConfig) {
-        val googlePlayDeployments = config.deployments.filterIsInstance<CdBuildConfig.Deployment.GooglePlay>()
-        val deploysByVariant = googlePlayDeployments.groupBy(CdBuildConfig.Deployment.GooglePlay::buildVariant)
-        deploysByVariant.forEach { (_, deploys) ->
-            if (deploys.size > 1) {
-                throw IllegalArgumentException("Must be one deploy per variant, but was: $googlePlayDeployments")
-            }
-        }
     }
 }
 

--- a/subprojects/gradle/upload-cd-build-result/src/test/kotlin/com/avito/cd/CdBuildConfigValidatorTest.kt
+++ b/subprojects/gradle/upload-cd-build-result/src/test/kotlin/com/avito/cd/CdBuildConfigValidatorTest.kt
@@ -1,0 +1,61 @@
+package com.avito.cd
+
+import com.avito.utils.logging.CILogger
+import com.avito.utils.logging.FakeCILogger
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CdBuildConfigValidatorTest {
+
+    @Test
+    fun `duplicated google play deployments with the same build variant`() {
+        val config = CdBuildConfig(
+            schemaVersion = 1,
+            project = NupokatiProject.AVITO,
+            releaseVersion = "248.0",
+            outputDescriptor = CdBuildConfig.OutputDescriptor(
+                path = "http://foo.bar",
+                skipUpload = true
+            ),
+            deployments = listOf(
+                CdBuildConfig.Deployment.GooglePlay(
+                    AndroidArtifactType.BUNDLE,
+                    BuildVariant.RELEASE,
+                    CdBuildConfig.Deployment.Track.ALPHA
+                ),
+                CdBuildConfig.Deployment.GooglePlay(
+                    AndroidArtifactType.APK,
+                    BuildVariant.RELEASE,
+                    CdBuildConfig.Deployment.Track.ALPHA
+                )
+            )
+        )
+        val error = assertThrows<RuntimeException> {
+            CdBuildConfigValidator(config, CILogger.allToStdout).validate()
+        }
+        assertThat(error).hasMessageThat().contains("Must be one deploy per variant")
+    }
+
+    @Test
+    fun `skip unknown deployment`() {
+        val config = CdBuildConfig(
+            schemaVersion = 1,
+            project = NupokatiProject.AVITO,
+            releaseVersion = "248.0",
+            outputDescriptor = CdBuildConfig.OutputDescriptor(
+                path = "http://foo.bar",
+                skipUpload = true
+            ),
+            deployments = listOf(
+                CdBuildConfig.Deployment.Unknown(
+                    type = "UnknownDeploymentType"
+                )
+            )
+        )
+        val logger = FakeCILogger()
+        CdBuildConfigValidator(config, logger).validate()
+
+        assertThat(logger.infoHandler.messages).contains("Ignore unknown CD config deployment: UnknownDeploymentType")
+    }
+}


### PR DESCRIPTION
We have two components: CD service ("Nupokati") and Android infrastructure. CD service runs the release build.
These components deployed independently. CD service works with multiple versions of Android infrastructure at the same time.

We need to support a new deployment type: #365

To achieve backward compatibility I've chosen to support it on the config level. 
Config has a schema version, but it will be inconvenient in CD service to know about client version.