### PR TITLE
MBS-8494 Log publish errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -317,6 +317,9 @@ fun Project.configureBintray(vararg publications: String) {
 
         dryRun = false
         publish = true
+        // You can use override for inconsistently uploaded artifacts
+        // Example: NoHttpResponseException: api.bintray.com:443 failed to respond (https://github.com/bintray/gradle-bintray-plugin/issues/325)
+        override = false
         pkg(closureOf<PackageConfig> {
             repo = "maven"
             userOrg = "avito"

--- a/publish.sh
+++ b/publish.sh
@@ -4,4 +4,4 @@
 
 source $(dirname $0)/_main.sh
 
-runInBuilder "./gradlew publishRelease ${GRADLE_ARGS} --no-parallel"
+runInBuilder "./gradlew publishRelease ${GRADLE_ARGS} --no-parallel --stacktrace"


### PR DESCRIPTION
I've faced with an error:

```
Execution failed for task ':subprojects:common:file-storage:bintrayUpload'.
  > org.apache.http.NoHttpResponseException: api.bintray.com:443 failed to respond
```