### PR TITLE
MBS-8423 Update keeper

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -51,7 +51,7 @@ object Dependencies {
     val asm = "org.ow2.asm:asm:7.1"
 
     //https://r8.googlesource.com/r8/
-    val r8 = "com.android.tools:r8:1.6.58"
+    val r8 = "com.android.tools:r8:1.6.89"
     val playServicesMaps = "com.google.android.gms:play-services-maps:17.0.0"
     val appcompat = "androidx.appcompat:appcompat:${Versions.androidX}"
     val recyclerView = "androidx.recyclerview:recyclerview:${Versions.androidX}"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -182,7 +182,7 @@ pluginManagement {
                     useModule("com.avito.android:${pluginId.removePrefix("com.avito.android.")}:$infraVersion")
 
                 pluginId == "com.slack.keeper" ->
-                    useModule("com.slack.keeper:keeper:0.2.0")
+                    useModule("com.slack.keeper:keeper:0.4.3")
             }
         }
     }


### PR DESCRIPTION
https://github.com/slackhq/keeper/blob/master/CHANGELOG.md

- Gradle 6.4 support
- Uses Zipflinger for packaging, which should give a nice speed boost in creating intermediate jars