### PR TITLE
MBS-8552 update android-builder docker image

### DIFF
--- a/_main.sh
+++ b/_main.sh
@@ -85,8 +85,6 @@ GRADLE_ARGS="-PartifactoryUrl=$ARTIFACTORY_URL \\
              -Pavito.slack.test.workspace=$SLACK_TEST_WORKSPACE \\
              -Pavito.bitbucket.enabled=true"
 
-# TODO: Use IMAGE_ANDROID_BUILDER image from public registry
-
 function runInBuilder() {
     COMMANDS=$@
 
@@ -99,6 +97,6 @@ function runInBuilder() {
     --env GRADLE_USER_HOME=/gradle \
     --env LOCAL_USER_ID="$USER_ID" \
     --env BINTRAY_GPG_PASSPHRASE="$BINTRAY_GPG_PASSPHRASE" \
-    dsvoronin/android-builder \
+    ${IMAGE_ANDROID_BUILDER} \
     bash -c "${GIT_COMMANDS} ${COMMANDS}"
 }

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,6 @@ source $(dirname $0)/_main.sh
 
 docs/check.sh
 
-# `tasks` triggers full tasks graph resolving, checking for possible misconfigurations
 runInBuilder "set -e;
     ./gradlew help;
     ./gradlew help -PuseCompositeBuild=false;

--- a/ci/_environment.sh
+++ b/ci/_environment.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
+ANDROID_BUILDER_TAG=c135d5bba0fa
+
 if [[ -z "${DOCKER_REGISTRY+x}" ]]; then
-    echo "ERROR: env DOCKER_REGISTRY is not specified"
-    exit 1
+    # using dockerhub for public availability
+    IMAGE_ANDROID_BUILDER=avitotech/android-builder:$ANDROID_BUILDER_TAG
+else
+    # using in-house proxy for performance
+    IMAGE_ANDROID_BUILDER=${DOCKER_REGISTRY}/android/builder:$ANDROID_BUILDER_TAG
 fi
 
-IMAGE_ANDROID_BUILDER=${DOCKER_REGISTRY}/android/builder:fadc2f33db
 IMAGE_DOCKER_IN_DOCKER=${DOCKER_REGISTRY}/android/docker-in-docker-image:c2ecce3a3e

--- a/ci/_environment.sh
+++ b/ci/_environment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ANDROID_BUILDER_TAG=c135d5bba0fa
+ANDROID_BUILDER_TAG=c135d5bba0
 
 if [[ -z "${DOCKER_REGISTRY+x}" ]]; then
     # using dockerhub for public availability

--- a/ci/docker/android-builder/Dockerfile
+++ b/ci/docker/android-builder/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:19.04
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
   apt-get update && \
@@ -7,33 +9,16 @@ RUN \
     curl \
     git \
     gcc \
-    rpl \
     openssh-client \
-    build-essential \
     ca-certificates \
-    docker.io \
     acl \
     sudo \
-    ruby ruby-dev \
-    openjdk-8-jdk \
-    python3-pip && \
+    openjdk-8-jdk && \
   apt-get clean && \
   apt-get purge
 
-RUN pip3 install --upgrade \
-  requests \
-  fire \
-  slackweb \
-  pandas \
-  lxml \
-  statsd
-
-# Fastlane to deploy stuff
-RUN gem install fastlane --no-document -v 2.135.2
-
 ENV LANG C.UTF-8
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
-ENV PYTHONUNBUFFERED 1
 
 # --------------- Gradle Profiler -----------------
 # https://github.com/gradle/gradle-profiler/releases
@@ -64,7 +49,6 @@ RUN curl $ANDROID_SDK_URL --progress-bar --location --output $ANDROID_SDK_FILE_N
 
 # Update sdk and install components
 # --package_file is broken https://issuetracker.google.com/issues/66465833
-# Use multiple platforms while upgrading for backward compatibility in buildOnTargetCommit task
 RUN mkdir $HOME/.android && \
   # empty file to mitigate warning
   touch $HOME/.android/repositories.cfg && \

--- a/ci/docker/android-builder/entrypoint.sh
+++ b/ci/docker/android-builder/entrypoint.sh
@@ -13,7 +13,6 @@ useradd --shell /bin/bash --uid "${USER_ID}" --gid "${USER_ID}" --comment "User 
 
 mkdir -p "${GRADLE_USER_HOME}"
 
-# были проблемы, когда создавал git при первом обращении
 SSH_DIR=/home/${BUILD_USER}/.ssh
 mkdir -p ${SSH_DIR}
 chown ${BUILD_USER} ${SSH_DIR}
@@ -24,6 +23,4 @@ find "${GRADLE_USER_HOME}" -maxdepth 3 -type d -not -user ${BUILD_USER} -print -
 # shellcheck disable=SC2145
 echo "Running command: $@"
 
-# Запускаем команды в докере от имении $BUILD_USER
-# Дополнитьно прокидываем PATH, т.к. не прокидывается через --preserve-env, как safe value
 sudo --set-home --preserve-env "PATH=$PATH" -u ${BUILD_USER} "$@"

--- a/ci/docker/python-profiler/Dockerfile
+++ b/ci/docker/python-profiler/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.7-alpine
+
+RUN pip3 install --upgrade statsd

--- a/ci/docker/python-profiler/README.md
+++ b/ci/docker/python-profiler/README.md
@@ -1,0 +1,1 @@
+Some scripts to parse and send gradle-profiler results are in python

--- a/ci/docker/python-profiler/image.yaml
+++ b/ci/docker/python-profiler/image.yaml
@@ -1,0 +1,2 @@
+registry: DOCKER_REGISTRY
+image: android/python-profiler

--- a/subprojects/build.gradle.kts
+++ b/subprojects/build.gradle.kts
@@ -30,7 +30,7 @@ val projectVersion: String by project
  * We use exact version to provide consistent environment and avoid build cache issues
  * (AGP tasks has artifacts from build tools)
  */
-val buildTools = "29.0.2"
+val buildTools = "29.0.3"
 val javaVersion = JavaVersion.VERSION_1_8
 val compileSdk = 29
 


### PR DESCRIPTION
ubuntu 19.04 (end of support) -> 20.04 (LTS)

remove ruby and python usage

actual version now used to build this project

update buildTools version 29.0.2->29.0.3 to match version from docker image (prevents runtime installation)