### PR TITLE
MBS-8790 Delete redundant api

### DIFF
--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/screen/ScreenChecks.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/screen/ScreenChecks.kt
@@ -1,6 +1,5 @@
 package com.avito.android.screen
 
-import android.annotation.SuppressLint
 import androidx.annotation.CallSuper
 import androidx.test.espresso.matcher.ViewMatchers
 import com.avito.android.screen.Screen.Companion.UNKNOWN_ROOT_ID
@@ -11,38 +10,20 @@ import com.avito.android.test.page_object.ViewElement
  */
 interface ScreenChecks {
 
-    @Deprecated("Will be deleted in 2020.9")
-    val screen: Screen
-
     val checkOnEachScreenInteraction: Boolean
         get() = false
 
-    @Deprecated("Use isScreenOpened() instead. Will be deleted in 2020.9",
-        replaceWith = ReplaceWith("isScreenOpened()")
-    )
-    @CallSuper
-    fun isOpened() {
-        screen.checkRootId()
-    }
-
-    fun isScreenOpened() {
-
-    }
+    fun isScreenOpened()
 }
 
 open class StrictScreenChecks(
-    override val screen: Screen,
+    protected val screen: Screen,
     override val checkOnEachScreenInteraction: Boolean = true
 ) : ScreenChecks {
 
     @CallSuper
     override fun isScreenOpened() {
         screen.checkRootId()
-    }
-
-    @SuppressLint("MissingSuperCall")
-    final override fun isOpened() {
-        isScreenOpened()
     }
 }
 


### PR DESCRIPTION
isOpened unused
screen is needed only for isOpened