### PR TITLE
MBS-8782 Enable impact analysis in CI steps by default

### DIFF
--- a/docs/content/docs/projects/CiSteps.md
+++ b/docs/content/docs/projects/CiSteps.md
@@ -123,7 +123,7 @@ uiTests {
   configurations("configurationName") // list of instrumentation configuration to depends on
   sendStatistics = false // by default
   suppressFailures = false // by default
-  useImpactAnalysis = false // by default
+  useImpactAnalysis = true // by default
   suppressFlaky = false // by default. [игнорирование падений FlakyTest]({{< ref "/docs/test/FlakyTests.md" >}}).
 }
 ```
@@ -136,7 +136,7 @@ uiTests {
   configurations = ["configurationName"] // list of instrumentation configuration to depends on
   sendStatistics = false // by default
   suppressFailures = false // by default
-  useImpactAnalysis = false // by default
+  useImpactAnalysis = true // by default
   suppressFlaky = false // by default. [игнорирование падений FlakyTest]({{< ref "/docs/test/FlakyTests.md" >}}).
 }
 ```
@@ -414,7 +414,6 @@ Step could use [Impact analysis]({{< ref "/docs/ci/ImpactAnalysis.md" >}}). It i
 ```kotlin
 fastCheck {
     uiTests {
-        useImpactAnalysis = true
     }
 }
 ```
@@ -425,7 +424,6 @@ fastCheck {
 ```groovy
 fastCheck {
     uiTests {
-        useImpactAnalysis = true
     }
 }
 ```

--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/BuildStepListExtension.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/BuildStepListExtension.kt
@@ -29,7 +29,7 @@ open class BuildStepListExtension(internal val name: String, objects: ObjectFact
     internal val steps: ListProperty<BuildStep> = objects.listProperty(BuildStep::class.java).empty()
 
     //todo property
-    var useImpactAnalysis: Boolean = false
+    var useImpactAnalysis: Boolean = true
 
     val taskDescription = objects.property<String>()
 

--- a/subprojects/gradle/cd/src/test/kotlin/com/avito/ci/step/UploadToQappsTest.kt
+++ b/subprojects/gradle/cd/src/test/kotlin/com/avito/ci/step/UploadToQappsTest.kt
@@ -126,6 +126,7 @@ class UploadToQappsTest {
                             }
                             builds {
                                 release {
+                                    useImpactAnalysis = false
                                     artifacts {
                                         apk("debug", com.avito.cd.BuildVariant.DEBUG, "com.app", "${'$'}buildDir/outputs/apk/debug/app-debug.apk") {}
                                     }


### PR DESCRIPTION
It's a stable optimization and we don't want to miss it accidentally.