### PR TITLE
MBS-7702 specify commons-io explicitly to use fixed version of Tailer

### DIFF
--- a/buildscript/src/main/kotlin/Dependencies.kt
+++ b/buildscript/src/main/kotlin/Dependencies.kt
@@ -47,6 +47,7 @@ object Dependencies {
     val kubernetesDsl = "com.fkorotkov:kubernetes-dsl:2.7.1"
     val dexlib = "org.smali:dexlib2:2.3"
     val commonsText = "org.apache.commons:commons-text:1.6"
+    val commonsIo = "commons-io:commons-io:2.7"
     val antPattern = "io.github.azagniotov:ant-style-path-matcher:1.0.0"
     val dockerClient = "de.gesellix:docker-client:2019-11-26T12-39-35"
     val asm = "org.ow2.asm:asm:7.1"

--- a/subprojects/gradle/instrumentation-tests/build.gradle.kts
+++ b/subprojects/gradle/instrumentation-tests/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
     implementation(Dependencies.retrofit)
     implementation(Dependencies.kotson)
     implementation(Dependencies.funktionaleTry)
+    implementation(Dependencies.commonsIo) {
+        because("LogcatBuffer.Impl.tailer needs to consider Charset (https://issues.apache.org/jira/browse/IO-354)")
+    }
 
     testImplementation(project(":gradle:test-project"))
     testImplementation(project(":gradle:logging-test-fixtures"))


### PR DESCRIPTION
The problem with mojibake in the log was in Tailer from an outdated version of `commons-io`. That outdated Tailer wasn't considering `Charset` when reading strings from a file. Android's LogCat has UTF-8 encoding but Java has UTF-16 encoding. So Cyrillic symbols were shown incorrectly. 

Futhermore outdated version of `commons-io` was given transitively through `project(":gradle:android")`. I've updated `commons-io` to the latest version where Tailer uses `Charset.defaultCharset()` to decode string.