### PR TITLE
MBS-8026 Remove from logs unrelated exceptions

### DIFF
--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
@@ -321,6 +321,21 @@ abstract class InHouseInstrumentationTestRunner :
         arguments.putString("newRunListenerMode", "true")
     }
 
+    override fun finish(resultCode: Int, results: Bundle?) {
+        try {
+            super.finish(resultCode, results)
+        } catch (e: IllegalStateException) {
+            // we made a research.
+            // It showed that IllegalStateException("UiAutomation not connected") occurs unrelated to our code.
+            // We use uiAutomation only for VideoCapture but without capturing this exception occurs with same frequency
+            if (e.message?.contains("UiAutomation not connected") != true) {
+                throw e
+            } else {
+                Log.d(tag, "Got UiAutomation not connected when finished")
+            }
+        }
+    }
+
     companion object {
         val instance: InHouseInstrumentationTestRunner by lazy {
             InstrumentationRegistry.getInstrumentation() as InHouseInstrumentationTestRunner


### PR DESCRIPTION
### UIAutomation not connected
Exception occurs when test execution ended during `Instrumentation.finish()`
<img width="1139" alt="Screenshot 2020-07-21 at 17 23 14" src="https://user-images.githubusercontent.com/8560287/88170851-0a7d5c00-cc27-11ea-99f5-23232a34799f.png">
Let’s look closer to the `finish` function. As we see `Instrumentation` tried to `mUiAutimation.disconnect` and `mUiAtomation` must exist and be not destroyed.
<img width="648" alt="Screenshot 2020-07-21 at 17 24 59" src="https://user-images.githubusercontent.com/8560287/88170939-2bde4800-cc27-11ea-9b2b-f20e85753157.png">
I’ve searched and found only one place where `mUiAutomation` is created.
It’s the `Instrumentation.getUiAutomation` function.
<img width="798" alt="Screenshot 2020-07-21 at 17 27 01" src="https://user-images.githubusercontent.com/8560287/88171003-47e1e980-cc27-11ea-804f-6633f0c81048.png">
So I decided to find all places where the `getUiAutomation` is executed.
I overrode the `getUiAutomation` and add logging there.
I used logging because I think attach and debug could affect the behavior more then logging.
<img width="606" alt="Screenshot 2020-07-21 at 17 28 54" src="https://user-images.githubusercontent.com/8560287/88171125-7cee3c00-cc27-11ea-8153-2a3071fc82d0.png">
I knew that we used video capturing that uses `mUiAutomation` on devices with API greater than 23. So I observed two API versions: 22, 28
I ran a simple test 10 times on each of those APIs.
#### on 22 API
I didn’t see `getUiAutomation` logs. So anyone didn’t call `getUiAutomation` function but `UiAutomation not connected` still occurs
Sum up: I don’t know Who, When, and How created `mUiAutomation`. So I don’t have any idea how to influence on that behavior.
#### on 28 API
Logs contained `getUiAutomation`. And I could connect this with video capturing. `com.avito.android.test.report.video.VideoCapturerImpl#execute`
<img width="1484" alt="Screenshot 2020-07-21 at 17 33 42" src="https://user-images.githubusercontent.com/8560287/88171254-ac9d4400-cc27-11ea-8c3a-adb74179db20.png">
More `getUiAutomation` logs. There we could see that system created `getUiAutomation` too
<img width="1464" alt="7-21 141124 615" src="https://user-images.githubusercontent.com/8560287/88171994-f6d2f500-cc28-11ea-8867-26d9027342be.png">

`UiAutomation not connected` still occurs
Sum up: `mUiAutomation` was created. But It’s not clear why exception occurs

Let’s look closer to `UiAutomatuion.disconnect()` function
<img width="685" alt="Screenshot 2020-07-21 at 17 40 00" src="https://user-images.githubusercontent.com/8560287/88171355-dce4e280-cc27-11ea-9368-bfc70729d63a.png">￼
We got exception in the `throwIfNotConnectedLocked()`. 
<img width="618" alt="Screenshot 2020-07-21 at 17 45 11" src="https://user-images.githubusercontent.com/8560287/88171394-ea9a6800-cc27-11ea-93d1-eb42c8720a40.png">
￼<img width="594" alt="Screenshot 2020-07-21 at 17 45 49" src="https://user-images.githubusercontent.com/8560287/88171397-ebcb9500-cc27-11ea-81c4-e2ffeec841a2.png">
On two above pictures we could see that `disconnect` made `mConnectionId = CONNECTION_ID_UNDEFINED` and exception occurs if `mConnectionId == CONNECTION_ID_UNDEFINED`
Sum up: If two threads call `disconnect` concurrently and It will lead to an exception. Because after second waiting thread will get the `mLock` it will fail at `throwIfNotConnectedLocked`

I found one place where `UiAutomation.disconnect()` is called. It’s the `Instrumentation.finish()`. So I decided to log the `finish` invocation
￼<img width="473" alt="Screenshot 2020-07-21 at 17 51 50" src="https://user-images.githubusercontent.com/8560287/88171398-ec642b80-cc27-11ea-8b4f-b6428bbf60b7.png">
I saw in logs only one `finish` for both APIs.
Sum up: We need to find other places where `UiAutomation.disconnect()` is called.

I searched through all usages of `instrumentation.getUiautomation` I was able to find but I didn’t see any `disconnect` calls

Summary: Exception occurs even on APIs where we don’t use the `UiAutomation` and I couldn’t find any related to `UiAutomation` logic. So I think we couldn’t control it and influence on that behavior.
The best decision is to catch that exception