### PR TITLE
MBS-9078 Log an original error from adb interaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ params +=-PinfraVersion=$(infra)
 endif
 
 ifeq ($(gradle_debug),true)
-params +=-Dorg.gradle.jvmargs='-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=5005,suspend=y' --no-daemon
+params +=-Dorg.gradle.debug=true --no-daemon
 endif
 
 ifeq ($(dry_run),true)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,9 +168,7 @@ subprojects {
                         }
 
                         testsCountBasedReservation {
-                            // Replace 27 with 28 when 2020.6.1 will be released
-                            //device = com.avito.instrumentation.reservation.request.Device.LocalEmulator.device(28, "Android_SDK_built_for_x86_64")
-                            device = Device.LocalEmulator.device(27)
+                            device = Device.LocalEmulator.device(28, "Android_SDK_built_for_x86_64")
                             maximum = 1
                             minimum = 1
                             testsPerEmulator = 1

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/Http.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/Http.kt
@@ -16,6 +16,10 @@ internal fun createReportHttpClient(): OkHttpClient {
                 Log.v("ReportViewerHttp", msg)
             }
 
+            override fun info(msg: String) {
+                Log.v("ReportViewerHttp", msg)
+            }
+
             override fun exception(msg: String, error: Throwable) {
                 Log.v("ReportViewerHttp", msg, error)
             }

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
@@ -64,6 +64,14 @@ abstract class InHouseInstrumentationTestRunner :
             Log.d("TestReport", msg)
         }
 
+        override fun info(msg: String) {
+            Log.i("TestReport", msg)
+        }
+
+        override fun warn(msg: String, error: Throwable?) {
+            Log.w("TestReport", msg, error)
+        }
+
         override fun exception(msg: String, error: Throwable) {
             Log.e("TestReport", msg, error)
         }
@@ -71,10 +79,6 @@ abstract class InHouseInstrumentationTestRunner :
         override fun critical(msg: String, error: Throwable) {
             Log.e("TestReport", msg, error)
             sentry.sendException(error)
-        }
-
-        override fun warn(msg: String, error: Throwable?) {
-            Log.w("TestReport", msg, error)
         }
     }
 

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/video/VideoCaptureTestListener.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/video/VideoCaptureTestListener.kt
@@ -28,6 +28,10 @@ class VideoCaptureTestListener(
             Log.d(LOG_TAG, msg)
         }
 
+        override fun info(msg: String) {
+            Log.i(LOG_TAG, msg)
+        }
+
         override fun exception(msg: String, error: Throwable) {
             Log.e(LOG_TAG, msg, error)
         }

--- a/subprojects/android-test/test-report/src/test/kotlin/com/avito/android/test/report/ReportTestExtension.kt
+++ b/subprojects/android-test/test-report/src/test/kotlin/com/avito/android/test/report/ReportTestExtension.kt
@@ -8,7 +8,7 @@ import com.avito.android.test.report.performance.PerformanceTestReporter
 import com.avito.android.test.report.screenshot.ScreenshotUploader
 import com.avito.android.test.report.transport.LocalRunTransport
 import com.avito.filestorage.RemoteStorage
-import com.avito.logger.FakeLogger
+import com.avito.logger.NoOpLogger
 import com.avito.logger.Logger
 import com.avito.report.model.DeviceName
 import com.avito.report.model.Flakiness
@@ -36,7 +36,7 @@ class ReportTestExtension(
     val fileStorageUrl: String = "https://filestorage.com",
     private val mockInterceptor: MockInterceptor = MockInterceptor(),
     private val screenshotUploader: ScreenshotUploader = mock(),
-    private val logger: Logger = FakeLogger,
+    private val logger: Logger = NoOpLogger,
     private val testRunCoordinates: ReportCoordinates = ReportCoordinates(
         planSlug = "android-test",
         jobSlug = "android-test",

--- a/subprojects/common/logger-test-fixtures/src/main/kotlin/com/avito/logger/NoOpLogger.kt
+++ b/subprojects/common/logger-test-fixtures/src/main/kotlin/com/avito/logger/NoOpLogger.kt
@@ -1,8 +1,10 @@
 package com.avito.logger
 
-object FakeLogger: Logger {
+object NoOpLogger: Logger {
 
     override fun debug(msg: String) {}
+
+    override fun info(msg: String) {}
 
     override fun warn(msg: String, error: Throwable?) {}
 

--- a/subprojects/common/logger/src/main/kotlin/com.avito.logger/Logger.kt
+++ b/subprojects/common/logger/src/main/kotlin/com.avito.logger/Logger.kt
@@ -2,6 +2,7 @@ package com.avito.logger
 
 interface Logger {
     fun debug(msg: String)
+    fun info(msg: String)
     fun warn(msg: String, error: Throwable? = null)
     fun exception(msg: String, error: Throwable)
     fun critical(msg: String, error: Throwable)

--- a/subprojects/common/logger/src/main/kotlin/com.avito.logger/Logger.kt
+++ b/subprojects/common/logger/src/main/kotlin/com.avito.logger/Logger.kt
@@ -2,7 +2,8 @@ package com.avito.logger
 
 interface Logger {
     fun debug(msg: String)
-    fun info(msg: String)
+    // TODO: implement in clients and remove empty implementation
+    fun info(msg: String) {} // empty implementation is for backward compatibility
     fun warn(msg: String, error: Throwable? = null)
     fun exception(msg: String, error: Throwable)
     fun critical(msg: String, error: Throwable)

--- a/subprojects/common/okhttp/src/test/kotlin/com/avito/http/RetryInterceptorTest.kt
+++ b/subprojects/common/okhttp/src/test/kotlin/com/avito/http/RetryInterceptorTest.kt
@@ -1,7 +1,6 @@
 package com.avito.http
 
-import com.avito.logger.FakeLogger
-import com.avito.logger.Logger
+import com.avito.logger.NoOpLogger
 import com.google.common.truth.Truth.assertThat
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -103,7 +102,7 @@ internal class RetryInterceptorTest {
                 RetryInterceptor(
                     retries = maxAttempts,
                     delayMs = 1,
-                    logger = FakeLogger,
+                    logger = NoOpLogger,
                     allowedMethods = listOf("GET", "POST"),
                     useIncreasingDelay = false
                 )

--- a/subprojects/common/okhttp/src/test/kotlin/com/avito/http/RetryWithFallbackTest.kt
+++ b/subprojects/common/okhttp/src/test/kotlin/com/avito/http/RetryWithFallbackTest.kt
@@ -1,6 +1,6 @@
 package com.avito.http
 
-import com.avito.logger.FakeLogger
+import com.avito.logger.NoOpLogger
 import com.avito.test.http.Mock
 import com.avito.test.http.MockDispatcher
 import com.google.common.truth.Truth.assertThat
@@ -35,7 +35,7 @@ class RetryWithFallbackTest {
                 RetryInterceptor(
                     allowedMethods = listOf("POST"),
                     allowedCodes = listOf(503),
-                    logger = FakeLogger
+                    logger = NoOpLogger
                 )
             )
             addInterceptor(

--- a/subprojects/common/report-viewer-test-fixtures/src/main/kotlin/com/avito/report/MockReportsExtension.kt
+++ b/subprojects/common/report-viewer-test-fixtures/src/main/kotlin/com/avito/report/MockReportsExtension.kt
@@ -1,7 +1,6 @@
 package com.avito.report
 
-import com.avito.logger.FakeLogger
-import com.avito.logger.Logger
+import com.avito.logger.NoOpLogger
 import com.avito.test.http.MockDispatcher
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.extension.AfterEachCallback
@@ -23,7 +22,7 @@ class MockReportsExtension : BeforeEachCallback, AfterEachCallback, ParameterRes
                 realApi = ReportsApi.create(
                     host = mockWebServer.url("/").toString(),
                     fallbackUrl = "",
-                    logger = FakeLogger
+                    logger = NoOpLogger
                 ),
                 mockDispatcher = mockDispatcher
             )

--- a/subprojects/common/report-viewer/src/test/kotlin/com/avito/report/ReportsApiTest.kt
+++ b/subprojects/common/report-viewer/src/test/kotlin/com/avito/report/ReportsApiTest.kt
@@ -1,7 +1,6 @@
 package com.avito.report
 
-import com.avito.logger.FakeLogger
-import com.avito.logger.Logger
+import com.avito.logger.NoOpLogger
 import com.avito.report.model.GetReportResult
 import com.avito.report.model.ReportCoordinates
 import com.avito.test.gradle.fileFromJarResources
@@ -26,7 +25,7 @@ internal class ReportsApiTest {
         reportsApi = ReportsApi.create(
             host = host,
             fallbackUrl = "",
-            logger = FakeLogger
+            logger = NoOpLogger
         )
     }
 

--- a/subprojects/common/report-viewer/src/test/kotlin/com/avito/report/ReportsFetchApiImplTest.kt
+++ b/subprojects/common/report-viewer/src/test/kotlin/com/avito/report/ReportsFetchApiImplTest.kt
@@ -1,6 +1,6 @@
 package com.avito.report
 
-import com.avito.logger.FakeLogger
+import com.avito.logger.NoOpLogger
 import com.avito.test.gradle.fileFromJarResources
 import com.avito.test.http.Mock
 import com.avito.test.http.MockDispatcher
@@ -19,7 +19,7 @@ internal class ReportsFetchApiImplTest {
     private val fetchApi: ReportsFetchApi = ReportsApi.create(
         host = mockWebServer.url("/").toString(),
         fallbackUrl = "",
-        logger = FakeLogger
+        logger = NoOpLogger
     )
 
     @Test

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsWorkerAction.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/CollectTeamcityMetricsWorkerAction.kt
@@ -46,6 +46,10 @@ abstract class CollectTeamcityMetricsWorkerAction : WorkAction<Parameters> {
                 }
             }
 
+            override fun info(msg: String) {
+                ciLogger.info(msg)
+            }
+
             override fun warn(msg: String, error: Throwable?) {
                 ciLogger.warn(msg, error)
             }

--- a/subprojects/gradle/design-screenshots/src/main/kotlin/com/avito/plugin/AdbDeviceHandler.kt
+++ b/subprojects/gradle/design-screenshots/src/main/kotlin/com/avito/plugin/AdbDeviceHandler.kt
@@ -8,7 +8,7 @@ interface AdbDeviceHandler {
     fun resolve(eitherDevice: Either<Exception, AdbDevice>): AdbDevice
 }
 
-internal class AdbDeviceHandlerLocal(val ciLogger: CILogger) : AdbDeviceHandler {
+internal class AdbDeviceHandlerLocal(private val ciLogger: CILogger) : AdbDeviceHandler {
     override fun resolve(eitherDevice: Either<Exception, AdbDevice>): AdbDevice {
         if (eitherDevice.isRight()) {
             ciLogger.info("One device found, gonna start pulling")

--- a/subprojects/gradle/git/src/main/kotlin/com/avito/git/GitState.kt
+++ b/subprojects/gradle/git/src/main/kotlin/com/avito/git/GitState.kt
@@ -22,10 +22,3 @@ interface GitState {
 
 val GitState.isOnDefaultBranch: Boolean
     get() = currentBranch.name.asBranchWithoutOrigin() == this.defaultBranch.asBranchWithoutOrigin()
-
-@Deprecated("Since 2020.4.6; Will be removed")
-val GitState.isOnReleaseBranch: Boolean
-    get() {
-        val branch = currentBranch.name.asBranchWithoutOrigin()
-        return branch.startsWith("release/") || branch.startsWith("domofond-release-")
-    }

--- a/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/executing/TestExecutor.kt
+++ b/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/executing/TestExecutor.kt
@@ -7,7 +7,6 @@ import com.avito.instrumentation.reservation.client.ReservationClientFactory
 import com.avito.instrumentation.reservation.request.Reservation
 import com.avito.instrumentation.suite.model.TestWithTarget
 import com.avito.instrumentation.util.launchGroupedCoroutines
-import com.avito.runner.logging.Logger
 import com.avito.runner.scheduler.TestsRunnerClient
 import com.avito.runner.scheduler.args.Arguments
 import com.avito.runner.scheduler.runner.model.TestRunRequest
@@ -15,6 +14,7 @@ import com.avito.runner.service.model.TestCase
 import com.avito.runner.service.worker.device.Serial
 import com.avito.runner.service.worker.device.model.DeviceConfiguration
 import com.avito.utils.logging.CILogger
+import com.avito.utils.logging.commonLogger
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.toList
 import kotlinx.coroutines.runBlocking
@@ -104,15 +104,7 @@ interface TestExecutor {
                 val runnerArguments = Arguments(
                     outputDirectory = outputFolder(output),
                     devices = devices,
-                    logger = object : Logger {
-                        override fun notify(message: String, error: Throwable?) {
-                            logger.critical(message, error)
-                        }
-
-                        override fun log(message: String) {
-                            logger.info(message)
-                        }
-                    },
+                    logger = commonLogger(logger),
                     listener = testReporter,
                     requests = testRequests
                 )

--- a/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/reservation/client/ReservationClientFactory.kt
+++ b/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/reservation/client/ReservationClientFactory.kt
@@ -6,11 +6,11 @@ import com.avito.instrumentation.reservation.adb.AndroidDebugBridge
 import com.avito.instrumentation.reservation.adb.EmulatorsLogsReporter
 import com.avito.instrumentation.reservation.client.kubernetes.KubernetesReservationClient
 import com.avito.instrumentation.reservation.client.local.LocalReservationClient
-import com.avito.runner.logging.Logger
 import com.avito.runner.service.worker.device.adb.AdbDevicesManager
 import com.avito.utils.gradle.KubernetesCredentials
 import com.avito.utils.gradle.createKubernetesClient
 import com.avito.utils.logging.CILogger
+import com.avito.utils.logging.commonLogger
 import java.io.File
 
 interface ReservationClientFactory {
@@ -45,15 +45,7 @@ interface ReservationClientFactory {
             return if (configuration.isTargetLocalEmulators) {
                 LocalReservationClient(
                     androidDebugBridge = androidDebugBridge,
-                    devicesManager = AdbDevicesManager(logger = object : Logger {
-                        override fun notify(message: String, error: Throwable?) {
-                            logger.critical(message, error)
-                        }
-
-                        override fun log(message: String) {
-                            logger.info(message)
-                        }
-                    }),
+                    devicesManager = AdbDevicesManager(logger = commonLogger(logger)),
                     configurationName = configuration.name,
                     logger = logger,
                     emulatorsLogsReporter = emulatorsLogsReporter

--- a/subprojects/gradle/logging-test-fixtures/src/main/kotlin/com/avito/utils/logging/FakeCILogger.kt
+++ b/subprojects/gradle/logging-test-fixtures/src/main/kotlin/com/avito/utils/logging/FakeCILogger.kt
@@ -6,7 +6,7 @@ class FakeCILogger(
     val infoHandler: RecordingLoggingHandler = RecordingLoggingHandler(),
     val warnHandler: RecordingLoggingHandler = RecordingLoggingHandler(),
     val criticalHandler: RecordingLoggingHandler = RecordingLoggingHandler()
-) : com.avito.utils.logging.CILogger(
+) : CILogger(
     debugHandler = debugHandler,
     infoHandler = infoHandler,
     warnHandler = warnHandler,

--- a/subprojects/gradle/logging/src/main/kotlin/com/avito/utils/logging/Gradle.kt
+++ b/subprojects/gradle/logging/src/main/kotlin/com/avito/utils/logging/Gradle.kt
@@ -58,6 +58,11 @@ private fun defaultCILogger(
     )
 
     val logger = CILogger(
+        debugHandler = CILoggingCombinedHandler(
+            handlers = listOf(
+                destinationFileHandler
+            )
+        ),
         infoHandler = CILoggingCombinedHandler(
             handlers = listOf(
                 stdoutHandler,
@@ -75,11 +80,6 @@ private fun defaultCILogger(
                 stdoutHandler,
                 destinationFileHandler,
                 sentryHandler
-            )
-        ),
-        debugHandler = CILoggingCombinedHandler(
-            handlers = listOf(
-                destinationFileHandler
             )
         )
     )

--- a/subprojects/gradle/runner/client/build.gradle.kts
+++ b/subprojects/gradle/runner/client/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(Dependencies.coroutinesCore)
     implementation(Dependencies.gson)
 
+    testImplementation(project(":common:logger-test-fixtures"))
     testImplementation(project(":gradle:test-project"))
     testImplementation(project(":gradle:runner:shared-test"))
     testImplementation(Dependencies.kotlinReflect)

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/Entrypoint.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/Entrypoint.kt
@@ -32,14 +32,14 @@ internal class Entrypoint(
 
         reporter.report(summary)
 
-        logger.info(
+        logger.debug(
             "Test run finished. The results: " +
                 "passed = ${summary.successRunsCount}, " +
                 "failed = ${summary.failedRunsCount}, " +
                 "ignored = ${summary.ignoredRunsCount}, " +
                 "took ${summary.durationMilliseconds.millisecondsToHumanReadableTime()}."
         )
-        logger.info(
+        logger.debug(
             "Matching results: " +
                 "matched = ${summary.matchedCount}, " +
                 "mismatched = ${summary.mismatched}, " +

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/Entrypoint.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/Entrypoint.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.scheduler
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
 import com.avito.runner.millisecondsToHumanReadableTime
 import com.avito.runner.scheduler.report.Reporter
 import com.avito.runner.scheduler.report.SummaryReportMaker
@@ -32,15 +32,14 @@ internal class Entrypoint(
 
         reporter.report(summary)
 
-        logger.log("Test run finished")
-        logger.log(
-            "Runs results: " +
+        logger.info(
+            "Test run finished. The results: " +
                 "passed = ${summary.successRunsCount}, " +
                 "failed = ${summary.failedRunsCount}, " +
                 "ignored = ${summary.ignoredRunsCount}, " +
                 "took ${summary.durationMilliseconds.millisecondsToHumanReadableTime()}."
         )
-        logger.log(
+        logger.info(
             "Matching results: " +
                 "matched = ${summary.matchedCount}, " +
                 "mismatched = ${summary.mismatched}, " +

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/args/Arguments.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/args/Arguments.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.scheduler.args
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
 import com.avito.runner.scheduler.listener.TestLifecycleListener
 import com.avito.runner.scheduler.runner.model.TestRunRequest
 import com.avito.runner.service.worker.device.Serial

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/listener/ArtifactsTestListener.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/listener/ArtifactsTestListener.kt
@@ -63,7 +63,7 @@ class ArtifactsTestListener(
                 remotePath = testMetadataDirectory.toPath()
             ).get()
         } catch (t: Throwable) {
-            logger.critical("Failed to process artifacts from device", t)
+            logger.warn("Failed to process artifacts from device", t)
         }
 
         tempDirectory.delete()

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/listener/ArtifactsTestListener.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/listener/ArtifactsTestListener.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.scheduler.listener
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
 import com.avito.runner.service.listener.TestListener
 import com.avito.runner.service.model.TestCase
 import com.avito.runner.service.model.TestCaseRun
@@ -63,7 +63,7 @@ class ArtifactsTestListener(
                 remotePath = testMetadataDirectory.toPath()
             ).get()
         } catch (t: Throwable) {
-            logger.notify("Failed to process artifacts from device", t)
+            logger.critical("Failed to process artifacts from device", t)
         }
 
         tempDirectory.delete()

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/listener/LogListener.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/listener/LogListener.kt
@@ -30,7 +30,7 @@ class LogListener : TestListener {
             is TestCaseRun.Result.Ignored -> "IGNORED"
             is TestCaseRun.Result.Failed.InRun -> "FAILED"
             is TestCaseRun.Result.Failed.InfrastructureError -> {
-                device.notifyError(result.errorMessage, result.cause)
+                device.warn(result.errorMessage, result.cause)
                 "LOST"
             }
         }

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/TestRunnerImplementation.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/TestRunnerImplementation.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.scheduler.runner
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
 import com.avito.runner.scheduler.runner.client.TestExecutionClient
 import com.avito.runner.scheduler.runner.model.TestRunRequest
 import com.avito.runner.scheduler.runner.model.TestRunResult
@@ -30,7 +30,7 @@ class TestRunnerImplementation(
         for (result in schedulerCommunication.result) {
             results += result
 
-            logger.log(
+            logger.info(
                 "Result for test: ${result.request.testCase.testName} " +
                     "received after ${result.result.size} tries. Progress (${results.count()}/$expectedResultsCount)"
             )

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/TestRunnerImplementation.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/TestRunnerImplementation.kt
@@ -30,7 +30,7 @@ class TestRunnerImplementation(
         for (result in schedulerCommunication.result) {
             results += result
 
-            logger.info(
+            logger.debug(
                 "Result for test: ${result.request.testCase.testName} " +
                     "received after ${result.result.size} tries. Progress (${results.count()}/$expectedResultsCount)"
             )

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/scheduler/TestExecutionScheduler.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/scheduler/TestExecutionScheduler.kt
@@ -37,7 +37,7 @@ class TestExecutionScheduler(
                     }
                     is TestExecutionState.Verdict.Run -> {
                         verdict.intentions.forEach { intention ->
-                            logger.info("Retry intention: $intention")
+                            logger.debug("Retry intention: $intention")
                             executionClient.requests.send(
                                 ClientTestRunRequest(
                                     state = testRunResult.state,

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/scheduler/TestExecutionScheduler.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/scheduler/TestExecutionScheduler.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.scheduler.runner.scheduler
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
 import com.avito.runner.scheduler.runner.client.TestExecutionClient
 import com.avito.runner.scheduler.runner.client.model.ClientTestRunRequest
 import com.avito.runner.scheduler.runner.model.TestRunRequest
@@ -37,7 +37,7 @@ class TestExecutionScheduler(
                     }
                     is TestExecutionState.Verdict.Run -> {
                         verdict.intentions.forEach { intention ->
-                            logger.log("Retry intention: $intention")
+                            logger.info("Retry intention: $intention")
                             executionClient.requests.send(
                                 ClientTestRunRequest(
                                     state = testRunResult.state,

--- a/subprojects/gradle/runner/client/src/test/kotlin/com/avito/runner/scheduler/runner/RunnerIntegrationTest.kt
+++ b/subprojects/gradle/runner/client/src/test/kotlin/com/avito/runner/scheduler/runner/RunnerIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.avito.runner.scheduler.runner
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
+import com.avito.logger.NoOpLogger
 import com.avito.runner.logging.StdOutLogger
 import com.avito.runner.scheduler.runner.client.TestExecutionClient
 import com.avito.runner.scheduler.runner.model.TestRunRequest
@@ -577,7 +578,7 @@ class RunnerIntegrationTest {
     private fun provideRunner(
         observer: DevicesObserver,
         testListener: TestListener = NoOpListener,
-        logger: Logger = StdOutLogger(),
+        logger: Logger = NoOpLogger,
         outputDirectory: File = File("")
     ): TestRunner {
         val scheduler = TestExecutionScheduler(

--- a/subprojects/gradle/runner/service/build.gradle.kts
+++ b/subprojects/gradle/runner/service/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(Dependencies.coroutinesCore)
     implementation(Dependencies.rxJava)
 
+    testImplementation(project(":common:logger-test-fixtures"))
     testImplementation(project(":gradle:test-project"))
     testImplementation(project(":gradle:runner:shared-test"))
     testImplementation(Dependencies.kotlinReflect)

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/IntentionExecutionService.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/IntentionExecutionService.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.service
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
 import com.avito.runner.service.listener.TestListener
 import com.avito.runner.service.model.intention.Intention
 import com.avito.runner.service.model.intention.IntentionResult
@@ -63,10 +63,10 @@ class IntentionExecutionServiceImplementation(
             for (message in messages) {
                 when (message) {
                     is DeviceWorkerMessage.ApplicationInstalled -> {
-                        logger.log("Application: ${message.installation.installation.application} installed")
+                        logger.debug("Application: ${message.installation.installation.application} installed")
                     }
                     is DeviceWorkerMessage.WorkerFailed -> {
-                        logger.log(
+                        logger.info(
                             "Received worker failed message during executing intention:" +
                                 " ${message.intention}. Rescheduling..."
                         )

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/IntentionExecutionService.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/IntentionExecutionService.kt
@@ -66,7 +66,7 @@ class IntentionExecutionServiceImplementation(
                         logger.debug("Application: ${message.installation.installation.application} installed")
                     }
                     is DeviceWorkerMessage.WorkerFailed -> {
-                        logger.info(
+                        logger.debug(
                             "Received worker failed message during executing intention:" +
                                 " ${message.intention}. Rescheduling..."
                         )

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/DeviceWorker.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/DeviceWorker.kt
@@ -36,7 +36,7 @@ class DeviceWorker(
             checkDeviceAlive()
             device.state()
         } catch (t: Exception) {
-            device.notifyError("Error while checking device initial state", t)
+            device.warn("Error while checking device initial state", t)
             // No intention is lost. DeviceWorkerMessage.WorkerFailed event is unnecessary.
             // Can't use this device any more. ReservationClient will get a new one.
             return@launch
@@ -67,7 +67,7 @@ class DeviceWorker(
 
             } catch (t: Throwable) {
                 // means device worker is die. TODO release device
-                device.notifyError("Error during $intention processing", t)
+                device.warn("Error during $intention processing", t)
 
                 messagesChannel.send(
                     DeviceWorkerMessage.WorkerFailed(

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/Device.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/Device.kt
@@ -29,7 +29,7 @@ interface Device {
     fun deviceStatus(): DeviceStatus
 
     fun log(message: String)
-    fun notifyError(message: String, error: Throwable?)
+    fun warn(message: String, error: Throwable?)
 
     sealed class DeviceStatus {
         object Alive : DeviceStatus() {

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
@@ -3,9 +3,9 @@ package com.avito.runner.service.worker.device.adb
 import com.android.ddmlib.AndroidDebugBridge
 import com.android.ddmlib.DdmPreferences
 import com.android.ddmlib.IDevice
+import com.avito.logger.Logger
 import com.avito.runner.CommandLineExecutor
 import com.avito.runner.ProcessNotification
-import com.avito.runner.logging.Logger
 import com.avito.runner.retry
 import com.avito.runner.service.model.DeviceTestCaseRun
 import com.avito.runner.service.model.TestCase
@@ -422,11 +422,12 @@ data class AdbDevice(
         )
 
     override fun log(message: String) {
-        logger.log("$TAG $message")
+        logger.info("$TAG $message")
     }
 
     override fun notifyError(message: String, error: Throwable?) {
-        logger.notify("$TAG $message", error)
+        val error: Throwable = error ?: java.lang.RuntimeException(message)
+        logger.critical("$TAG $message", error)
     }
 
     override fun toString(): String {

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
@@ -47,8 +47,8 @@ data class AdbDevice(
                     cast = { it.toInt() }
                 )
             },
-            attemptFailedHandler = { attempt, throwable ->
-                logger.info("Attempt $attempt: reading ro.build.version.sdk failed. Reason: ${throwable.message}")
+            attemptFailedHandler = { attempt, _ ->
+                logger.info("Attempt $attempt: reading ro.build.version.sdk failed")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed reading ro.build.version.sdk", throwable)
@@ -71,8 +71,8 @@ data class AdbDevice(
                 adbDevice.installPackage(application, true)
                 logger.debug("Attempt $attempt: application $application installed")
             },
-            attemptFailedHandler = { attempt, throwable ->
-                logger.info("Attempt $attempt: failed to install application because of ${throwable.message}")
+            attemptFailedHandler = { attempt, _ ->
+                logger.info("Attempt $attempt: failed to install application $application")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed installing application $application", throwable)
@@ -177,8 +177,8 @@ data class AdbDevice(
 
                 Device.DeviceStatus.Alive
             },
-            attemptFailedHandler = { attempt, throwable ->
-                logger.info("Attempt $attempt: device is freezing. Reason: ${throwable.message}")
+            attemptFailedHandler = { attempt, _ ->
+                logger.info("Attempt $attempt: device is freezing")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed reading device status", throwable)
@@ -202,8 +202,8 @@ data class AdbDevice(
                 )
                 logger.debug("Attempt: $attempt: clear package $name completed")
             },
-            attemptFailedHandler = { attempt, throwable ->
-                logger.info("Attempt $attempt: failed to clear package. Reason: ${throwable.message}")
+            attemptFailedHandler = { attempt, _ ->
+                logger.info("Attempt $attempt: failed to clear package $name")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed clearing package $name", throwable)
@@ -236,11 +236,11 @@ data class AdbDevice(
                     )
                 }
             },
-            attemptFailedHandler = { attempt, throwable ->
-                logger.info("Attempt $attempt: failed to pull $from. Reason: ${throwable.message}")
+            attemptFailedHandler = { attempt, _ ->
+                logger.info("Attempt $attempt: failed to pull $from")
             },
             actionFailedHandler = { throwable ->
-                logger.warn("Failed pulling data", throwable)
+                logger.warn("Failed pulling data $from", throwable)
             }
         )
     }
@@ -258,8 +258,8 @@ data class AdbDevice(
                     )
                 )
             },
-            attemptFailedHandler = { attempt, throwable ->
-                logger.info("Attempt $attempt: failed to clear package $remotePath. Reason: ${throwable.message}")
+            attemptFailedHandler = { attempt, _ ->
+                logger.info("Attempt $attempt: failed to clear package $remotePath")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed clearing package $remotePath", throwable)
@@ -279,8 +279,8 @@ data class AdbDevice(
                     )
                 )
             },
-            attemptFailedHandler = { attempt, throwable ->
-                logger.info("Attempt $attempt: failed to list directory $remotePath. Reason: ${throwable.message}")
+            attemptFailedHandler = { attempt, _ ->
+                logger.info("Attempt $attempt: failed to list directory $remotePath")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed listing path $remotePath", throwable)

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
@@ -48,7 +48,7 @@ data class AdbDevice(
                 )
             },
             attemptFailedHandler = { attempt, _ ->
-                logger.info("Attempt $attempt: reading ro.build.version.sdk failed")
+                logger.debug("Attempt $attempt: reading ro.build.version.sdk failed")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed reading ro.build.version.sdk", throwable)
@@ -72,7 +72,7 @@ data class AdbDevice(
                 logger.debug("Attempt $attempt: application $application installed")
             },
             attemptFailedHandler = { attempt, _ ->
-                logger.info("Attempt $attempt: failed to install application $application")
+                logger.debug("Attempt $attempt: failed to install application $application")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed installing application $application", throwable)
@@ -178,7 +178,7 @@ data class AdbDevice(
                 Device.DeviceStatus.Alive
             },
             attemptFailedHandler = { attempt, _ ->
-                logger.info("Attempt $attempt: device is freezing")
+                logger.debug("Attempt $attempt: device is freezing")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed reading device status", throwable)
@@ -203,7 +203,7 @@ data class AdbDevice(
                 logger.debug("Attempt: $attempt: clear package $name completed")
             },
             attemptFailedHandler = { attempt, _ ->
-                logger.info("Attempt $attempt: failed to clear package $name")
+                logger.debug("Attempt $attempt: failed to clear package $name")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed clearing package $name", throwable)
@@ -237,7 +237,7 @@ data class AdbDevice(
                 }
             },
             attemptFailedHandler = { attempt, _ ->
-                logger.info("Attempt $attempt: failed to pull $from")
+                logger.debug("Attempt $attempt: failed to pull $from")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed pulling data $from", throwable)
@@ -259,7 +259,7 @@ data class AdbDevice(
                 )
             },
             attemptFailedHandler = { attempt, _ ->
-                logger.info("Attempt $attempt: failed to clear package $remotePath")
+                logger.debug("Attempt $attempt: failed to clear package $remotePath")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed clearing package $remotePath", throwable)
@@ -280,7 +280,7 @@ data class AdbDevice(
                 )
             },
             attemptFailedHandler = { attempt, _ ->
-                logger.info("Attempt $attempt: failed to list directory $remotePath")
+                logger.debug("Attempt $attempt: failed to list directory $remotePath")
             },
             actionFailedHandler = { throwable ->
                 logger.warn("Failed listing path $remotePath", throwable)
@@ -440,9 +440,8 @@ data class AdbDevice(
         logger.info("$TAG $message")
     }
 
-    override fun notifyError(message: String, error: Throwable?) {
-        val error: Throwable = error ?: java.lang.RuntimeException(message)
-        logger.critical("$TAG $message", error)
+    override fun warn(message: String, error: Throwable?) {
+        logger.warn("$TAG $message", error)
     }
 
     override fun toString(): String {

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevicesManager.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevicesManager.kt
@@ -1,8 +1,8 @@
 package com.avito.runner.service.worker.device.adb
 
+import com.avito.logger.Logger
 import com.avito.runner.CommandLineExecutor
 import com.avito.runner.ProcessNotification
-import com.avito.runner.logging.Logger
 import com.avito.runner.service.worker.device.Device
 import com.avito.runner.service.worker.device.DevicesManager
 
@@ -35,7 +35,7 @@ class AdbDevicesManager(
             .retry { retryCount, exception ->
                 val shouldRetry = retryCount < 5 && exception is IllegalStateException
                 if (shouldRetry) {
-                    logger.log("runningEmulators: retrying $exception.")
+                    logger.debug("runningEmulators: retrying $exception.")
                 }
 
                 shouldRetry
@@ -52,7 +52,9 @@ class AdbDevicesManager(
                         ) as Device
                     }.toSet()
             }
-            .doOnError { logger.log("Error on getting adb devices, error = $it") }
+            .doOnError {
+                logger.warn("Error on getting adb devices", it)
+            }
             .toSingle()
             .toBlocking()
             .value()

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/observer/ExternalIntentionBasedDevicesObserver.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/observer/ExternalIntentionBasedDevicesObserver.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.service.worker.device.observer
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
 import com.avito.runner.service.worker.device.Device
 import com.avito.runner.service.worker.device.DevicesManager
 import com.avito.runner.service.worker.device.Serial
@@ -19,7 +19,7 @@ class ExternalIntentionBasedDevicesObserver(
     override suspend fun observeDevices(): ReceiveChannel<Device> =
         externalIntentionOfSerials
             .map { intentionSerial ->
-                logger.log("Intention for serial: $intentionSerial received")
+                logger.debug("Intention for serial: $intentionSerial received")
 
                 devicesManager.connectedDevices()
                     .find { it.id == intentionSerial }

--- a/subprojects/gradle/runner/service/src/test/kotlin/com/avito/runner/service/IntentionExecutionServiceTest.kt
+++ b/subprojects/gradle/runner/service/src/test/kotlin/com/avito/runner/service/IntentionExecutionServiceTest.kt
@@ -1,5 +1,6 @@
 package com.avito.runner.service
 
+import com.avito.logger.NoOpLogger
 import com.avito.runner.logging.StdOutLogger
 import com.avito.runner.service.model.TestCaseRun
 import com.avito.runner.service.model.intention.State
@@ -226,7 +227,7 @@ class IntentionExecutionServiceTest {
         intentionsRouter: IntentionsRouter
     ) = IntentionExecutionServiceImplementation(
         outputDirectory = File(""),
-        logger = StdOutLogger(),
+        logger = NoOpLogger,
         devicesObserver = devicesObserver,
         intentionsRouter = intentionsRouter,
         listener = NoOpListener

--- a/subprojects/gradle/runner/shared-test/src/main/kotlin/com/avito/runner/test/mock/MockDevice.kt
+++ b/subprojects/gradle/runner/shared-test/src/main/kotlin/com/avito/runner/test/mock/MockDevice.kt
@@ -106,9 +106,8 @@ open class MockDevice(
         logger.info(message)
     }
 
-    override fun notifyError(message: String, error: Throwable?) {
-        val error: Throwable = error ?: java.lang.RuntimeException(message)
-        logger.critical(message, error)
+    override fun warn(message: String, error: Throwable?) {
+        logger.warn(message, error)
     }
 
     fun verify() {

--- a/subprojects/gradle/runner/shared-test/src/main/kotlin/com/avito/runner/test/mock/MockDevice.kt
+++ b/subprojects/gradle/runner/shared-test/src/main/kotlin/com/avito/runner/test/mock/MockDevice.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.test.mock
 
-import com.avito.runner.logging.Logger
+import com.avito.logger.Logger
 import com.avito.runner.service.model.DeviceTestCaseRun
 import com.avito.runner.service.model.TestCaseRun
 import com.avito.runner.service.model.intention.InstrumentationTestRunAction
@@ -103,11 +103,12 @@ open class MockDevice(
     }
 
     override fun log(message: String) {
-        logger.log(message)
+        logger.info(message)
     }
 
     override fun notifyError(message: String, error: Throwable?) {
-        logger.notify(message, error)
+        val error: Throwable = error ?: java.lang.RuntimeException(message)
+        logger.critical(message, error)
     }
 
     fun verify() {

--- a/subprojects/gradle/runner/shared/build.gradle.kts
+++ b/subprojects/gradle/runner/shared/build.gradle.kts
@@ -8,5 +8,6 @@ extra["artifact-id"] = "runner-shared"
 
 dependencies {
     compileOnly(gradleApi())
+    api(project(":common:logger"))
     implementation(Dependencies.rxJava)
 }

--- a/subprojects/gradle/runner/shared/src/main/kotlin/com/avito/runner/CommandLineExecutor.kt
+++ b/subprojects/gradle/runner/shared/src/main/kotlin/com/avito/runner/CommandLineExecutor.kt
@@ -67,15 +67,18 @@ interface CommandLineExecutor {
 
                 reader.close()
 
-                val exitCode = process.waitFor()
-
-                when (exitCode) {
+                when (val exitCode = process.waitFor()) {
                     0 -> {
                         emitter.onNext(ProcessNotification.Exit(buffer.toString()))
                         emitter.onCompleted()
                     }
                     else -> {
-                        emitter.onError(IllegalStateException("Process $commandAndArgs exited with non-zero code $exitCode"))
+                        emitter.onError(
+                            IllegalStateException(
+                                "Process $commandAndArgs exited with non-zero code $exitCode. " +
+                                    "Output: $buffer"
+                            )
+                        )
                     }
                 }
             }, Emitter.BackpressureMode.ERROR

--- a/subprojects/gradle/runner/shared/src/main/kotlin/com/avito/runner/logging/Logger.kt
+++ b/subprojects/gradle/runner/shared/src/main/kotlin/com/avito/runner/logging/Logger.kt
@@ -1,6 +1,0 @@
-package com.avito.runner.logging
-
-interface Logger {
-    fun log(message: String)
-    fun notify(message: String, error: Throwable? = null)
-}

--- a/subprojects/gradle/runner/shared/src/main/kotlin/com/avito/runner/logging/StdOutLogger.kt
+++ b/subprojects/gradle/runner/shared/src/main/kotlin/com/avito/runner/logging/StdOutLogger.kt
@@ -1,12 +1,26 @@
 package com.avito.runner.logging
 
+import com.avito.logger.Logger
+
 class StdOutLogger : Logger {
 
-    override fun notify(message: String, error: Throwable?) {
-        println("[error] $message ${error?.message}")
+    override fun debug(msg: String) {
+        println(msg)
     }
 
-    override fun log(message: String) {
-        println(message)
+    override fun info(msg: String) {
+        println(msg)
+    }
+
+    override fun warn(msg: String, error: Throwable?) {
+        println("WARN: $msg ${error?.message}")
+    }
+
+    override fun exception(msg: String, error: Throwable) {
+        println("ERROR: $msg ${error?.message}")
+    }
+
+    override fun critical(msg: String, error: Throwable) {
+        println("ERROR: $msg ${error?.message}")
     }
 }

--- a/subprojects/gradle/runner/shared/src/main/kotlin/com/avito/runner/logging/StdOutLogger.kt
+++ b/subprojects/gradle/runner/shared/src/main/kotlin/com/avito/runner/logging/StdOutLogger.kt
@@ -17,10 +17,10 @@ class StdOutLogger : Logger {
     }
 
     override fun exception(msg: String, error: Throwable) {
-        println("ERROR: $msg ${error?.message}")
+        println("ERROR: $msg ${error.message}")
     }
 
     override fun critical(msg: String, error: Throwable) {
-        println("ERROR: $msg ${error?.message}")
+        println("CRITICAL: $msg ${error.message}")
     }
 }

--- a/subprojects/gradle/utils/src/main/kotlin/com/avito/utils/logging/CILogger.kt
+++ b/subprojects/gradle/utils/src/main/kotlin/com/avito/utils/logging/CILogger.kt
@@ -25,12 +25,12 @@ open class CILogger(
         infoHandler.write(message, error)
     }
 
-    fun critical(message: String, error: Throwable? = null) {
-        criticalHandler.write(message, error)
-    }
-
     fun warn(message: String, error: Throwable? = null) {
         warnHandler.write(message, error)
+    }
+
+    fun critical(message: String, error: Throwable? = null) {
+        criticalHandler.write(message, error)
     }
 
     fun child(tag: String): CILogger = CILogger(
@@ -42,16 +42,16 @@ open class CILogger(
 
     companion object {
         val allToStdout = CILogger(
-            infoHandler = CILoggingHandlerImplementation(
+            debugHandler = CILoggingHandlerImplementation(
                 destination = StdoutDestination
             ),
-            criticalHandler = CILoggingHandlerImplementation(
+            infoHandler = CILoggingHandlerImplementation(
                 destination = StdoutDestination
             ),
             warnHandler = CILoggingHandlerImplementation(
                 destination = StdoutDestination
             ),
-            debugHandler = CILoggingHandlerImplementation(
+            criticalHandler = CILoggingHandlerImplementation(
                 destination = StdoutDestination
             )
         )

--- a/subprojects/gradle/utils/src/main/kotlin/com/avito/utils/logging/CommonLogger.kt
+++ b/subprojects/gradle/utils/src/main/kotlin/com/avito/utils/logging/CommonLogger.kt
@@ -9,8 +9,13 @@ fun commonLogger(ciLogger: CILogger): Logger {
 private class CILoggerWrapper(
     private val ciLogger: CILogger
 ) : Logger {
+
     override fun debug(msg: String) {
         ciLogger.debug(msg)
+    }
+
+    override fun info(msg: String) {
+        ciLogger.info(msg)
     }
 
     override fun exception(msg: String, error: Throwable) {


### PR DESCRIPTION
We were losing an original error from ADB commands.

Steps to reproduce:
- Run tests
- Kill Android emulator

Results:
```
Attempt 14: failed to ... Reason: 2 exceptions occurred. 
```
The reason is lost.

In this PR we [log the original error](https://github.com/avito-tech/avito-android/pull/523/files/1b42261b767c9b7a1e7737129897e54b39061945#r461674059) after the last attempt:
```
Attempt 14: device is freezing.

Failed reading device status
Process [/home/user/Android/Sdk/platform-tools/adb, -s, emulator-5554, shell, getprop, sys.boot_completed] exited with non-zero code 1. Output: adb: device 'emulator-5554' not found
```