### PR TITLE
Update Mirakle docs

### DIFF
--- a/docs/content/docs/assemble/Mirakle.md
+++ b/docs/content/docs/assemble/Mirakle.md
@@ -35,8 +35,7 @@ sequenceDiagram
         - Создай PR в указанный репозиторий
         - Попроси в чатике [#devops](https://avito.slack.com/archives/C02D4DCQ2) влить его
     - Запроси в [Service Desk (internal)](http://links.k.avito.ru/uZ) доступ по ssh на host android-builder
-- Включи mirakle: `./mirakle.py --enable`   
-Если локальный пользователь отличается: `./mirakle.py --enable --username <username>`
+- Включи mirakle: `./mirakle.py --enable`. `username` будет взят из `git user.email`
 - Проверь работу, запусти любую задачу: `./gradlew help`   
 В логе будут сообщения:
 


### PR DESCRIPTION
remove outdated info about `--username`
clarify how we get `username` for ssh