### PR TITLE
MBS-580 AGP 4.0.2 - bugfix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ android.useAndroidX=true
 # Current stable version to be used in this project
 infraVersion=2020.23
 systemProp.kotlinVersion=1.3.72
-systemProp.androidGradlePluginVersion=4.0.1
+systemProp.androidGradlePluginVersion=4.0.2
 avito.build=local
 avito.git.state=local
 # Without it failed on studio sync when ci=true. It happens because studio makes eager configuration of each register task.

--- a/subprojects/gradle.properties
+++ b/subprojects/gradle.properties
@@ -10,6 +10,6 @@ android.useAndroidX=true
 projectVersion=2020.24
 # TODO: MBS-9285 - https://github.com/gradle/gradle/issues/12660
 systemProp.kotlinVersion=1.3.72
-systemProp.androidGradlePluginVersion=4.0.1
+systemProp.androidGradlePluginVersion=4.0.2
 # Disable console output https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/202
 systemProp.dependency.analysis.silent=true


### PR DESCRIPTION
Dexer (D8):

Issue #158502561: Invalid Maven POM file for the desugar_jdk_libs_configuration artifact
Issue #160905482: Desugaring broken for subclasses of ConcurrentHashMap
Issue #160909126: coreLibraryDesugaringEnabled seems to break - ConcurrentHashMap when using Gson and reflection
Issue #159275214: [library desugar] Desugar java.util.TimeZone.getTimeZone(ZoneId zoneId)

Lint:

Issue #158128960: AGP 4.0 false positive Instantiatable Lint check if Application extends java class
Issue #155088391: Can no longer specify layout_height and layout_width in a style

Shrinker (R8):

Issue #160351050: Enum inlining uses the "wrong" name sometimes
Issue #160942326: Runtime errors when using R8 2.0+
Issue #167704467: Fatal Exception: java.lang.VerifyError
Issue #160901582: CompilationError during R8 phase when optimizations enabled
Issue #160769273: ConcurrentModificationException: TreeMap$PrivateEntryIterator.nextEntry