### PR TITLE
Fix RecyclerViewInteractionContext.kt

### DIFF
--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/espresso/action/recycler/RecyclerItemMatching.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/espresso/action/recycler/RecyclerItemMatching.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.intent.Checks.checkArgument
 import androidx.test.espresso.util.HumanReadables
+import com.avito.android.test.matcher.DescendantViewMatcher
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
@@ -236,17 +237,20 @@ internal class RecyclerItemsMatcher(
     }
 }
 
-fun <VH : RecyclerView.ViewHolder> viewHolderMatcher(itemViewMatcher: Matcher<View>) =
-    object : TypeSafeMatcher<VH>() {
-        override fun matchesSafely(viewHolder: VH): Boolean {
-            return itemViewMatcher.matches(viewHolder.itemView)
-        }
+fun <VH : RecyclerView.ViewHolder> viewHolderMatcher(
+    itemViewMatcher: Matcher<View>
+) = object : TypeSafeMatcher<VH>() {
+    private val matcher = DescendantViewMatcher(itemViewMatcher)
 
-        override fun describeTo(description: Description) {
-            description.appendText("holder with view: ")
-            itemViewMatcher.describeTo(description)
-        }
+    override fun matchesSafely(viewHolder: VH): Boolean {
+        return matcher.matches(viewHolder.itemView)
     }
+
+    override fun describeTo(description: Description) {
+        description.appendText("holder with view: ")
+        description.appendDescriptionOf(matcher)
+    }
+}
 
 internal class MatchedItem(
     val position: Int,

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/matcher/DescendantViewMatcher.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/matcher/DescendantViewMatcher.kt
@@ -1,0 +1,48 @@
+package com.avito.android.test.matcher
+
+import android.view.View
+import androidx.test.espresso.AmbiguousViewMatcherException
+import androidx.test.espresso.util.TreeIterables
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+
+/**
+ * Copied from [ViewFinderHelper]
+ */
+internal class DescendantViewMatcher(private val matcher: Matcher<View>) : TypeSafeMatcher<View>() {
+
+    override fun describeTo(description: Description) {
+        description.appendText("Match has descendant view: ")
+            .appendDescriptionOf(matcher)
+    }
+
+    override fun matchesSafely(item: View): Boolean {
+        val matchedViewsSequence: Sequence<View> = TreeIterables.breadthFirstViewTraversal(item)
+            .asSequence()
+            .filter { matcher.matches(it) }
+
+        val matchedViews = matchedViewsSequence.toList()
+
+        return when {
+            matchedViews.isEmpty() -> false
+            matchedViews.size == 1 -> true
+            else -> {
+
+                throw AmbiguousViewMatcherException.Builder()
+                    .withViewMatcher(matcher)
+                    .withRootView(item)
+                    .withView1(matchedViews[0])
+                    .withView2(matchedViews[1])
+                    .apply {
+                        if (matchedViews.size > 2) {
+                            withOtherAmbiguousViews(
+                                *matchedViews.takeLast(matchedViews.size - 2).toTypedArray()
+                            )
+                        }
+                    }
+                    .build()
+            }
+        }
+    }
+}

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/ListElement.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/ListElement.kt
@@ -15,7 +15,6 @@ import androidx.test.espresso.action.SwipeDirections.RIGHT_TO_LEFT
 import androidx.test.espresso.action.SwipeDirections.TOP_TO_BOTTOM
 import androidx.test.espresso.action.Swiper
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import com.avito.android.test.InteractionContext
 import com.avito.android.test.RecyclerViewInteractionContext
 import com.avito.android.test.SimpleInteractionContext
@@ -43,7 +42,6 @@ import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.greaterThan
 import org.hamcrest.TypeSafeMatcher
-import org.hamcrest.core.AnyOf.anyOf
 
 open class ListElement(interactionContext: InteractionContext) : ViewElement(interactionContext) {
 
@@ -68,8 +66,7 @@ open class ListElement(interactionContext: InteractionContext) : ViewElement(int
             .newInstance(
                 RecyclerViewInteractionContext(
                     interactionContext = interactionContext,
-                    cellMatcher = anyOf(hasDescendant(matcher), matcher),
-                    childMatcher = matcher,
+                    matcher = matcher,
                     position = position,
                     needScroll = needScroll
                 )


### PR DESCRIPTION
merge cell and child matcher because cellmatcher wasn't be propagated when `provideChildContext`