### PR TITLE
Slack client fix for nullable fields

### DIFF
--- a/subprojects/gradle/ci-logger/src/main/kotlin/com/avito/utils/logging/CILoggingDestination.kt
+++ b/subprojects/gradle/ci-logger/src/main/kotlin/com/avito/utils/logging/CILoggingDestination.kt
@@ -23,7 +23,7 @@ internal object StdoutDestination : CILoggingDestination {
 
     override fun write(message: String, throwable: Throwable?) {
         println(message)
-        throwable?.also { println(it) }
+        throwable?.also { println("  cause: $it") }
     }
 
     override fun child(tag: String): CILoggingDestination = this

--- a/subprojects/gradle/slack-test-fixtures/src/main/kotlin/com/avito/slack/model/FakeFoundMessage.kt
+++ b/subprojects/gradle/slack-test-fixtures/src/main/kotlin/com/avito/slack/model/FakeFoundMessage.kt
@@ -2,9 +2,16 @@ package com.avito.slack.model
 
 fun FoundMessage.Companion.createStubInstance(
     text: String = "",
-    botId: String = "",
+    botId: String? = null,
     timestamp: String = "",
     emoji: String? = null,
-    author: String = "",
+    author: String? = null,
     channel: SlackChannel = SlackChannel("#")
-) = FoundMessage(text = text, botId = botId, timestamp = timestamp, author = author, channel = channel, emoji = emoji)
+) = FoundMessage(
+    text = text,
+    botId = botId,
+    timestamp = timestamp,
+    author = author,
+    channel = channel,
+    emoji = emoji
+)

--- a/subprojects/gradle/slack/build.gradle.kts
+++ b/subprojects/gradle/slack/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(Dependencies.okhttp)
     implementation(Dependencies.coroutinesCore)
 
+    integTestImplementation(project(":gradle:kotlin-dsl-support"))
+
     testImplementation(project(":gradle:test-project"))
     testImplementation(project(":gradle:slack-test-fixtures"))
     testImplementation(project(":common:time-test-fixtures"))

--- a/subprojects/gradle/slack/src/integTest/kotlin/com/avito/slack/SlackConditionalSenderIntegrationTest.kt
+++ b/subprojects/gradle/slack/src/integTest/kotlin/com/avito/slack/SlackConditionalSenderIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.avito.slack
 
+import com.avito.kotlin.dsl.getSystemProperty
 import com.avito.slack.model.SlackChannel
 import com.avito.slack.model.SlackMessage
 import com.avito.slack.model.SlackSendMessageRequest
@@ -12,11 +13,9 @@ import java.util.UUID
 
 internal class SlackConditionalSenderIntegrationTest {
 
-    // todo хреново что для локального запуска нужно здесь ENV задавать
-    private val testChannel = SlackChannel(requireNotNull(System.getProperty("avito.slack.test.channel")))
-    private val testToken = requireNotNull(System.getProperty("avito.slack.test.token"))
-    private val slackClient: SlackClient =
-        SlackClient.Impl(testToken, requireNotNull(System.getProperty("avito.slack.test.workspace")))
+    private val testChannel = SlackChannel(getSystemProperty("avito.slack.test.channel"))
+    private val testToken = getSystemProperty("avito.slack.test.token")
+    private val slackClient: SlackClient = SlackClient.Impl(testToken, getSystemProperty("avito.slack.test.workspace"))
     private val logger: CILogger = CILogger.allToStdout
 
     @Test
@@ -73,7 +72,6 @@ internal class SlackConditionalSenderIntegrationTest {
         assertThat(secondMessageTry).isInstanceOf<Try.Success<*>>()
         assertThat(secondMessageTry.get().text).contains("second message")
 
-        // так проверяем что сообщение написано в треде к первому
         assertThat(secondMessageTry.get().threadId).isEqualTo(firstMessage.id)
     }
 

--- a/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackClient.kt
+++ b/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackClient.kt
@@ -34,9 +34,9 @@ interface SlackClient : SlackMessageSender, SlackFileUploader {
         private val methodsClient: MethodsClient = Slack.getInstance().methods()
 
         /**
-         * для [findMessage] фетчим [messagesLookupCount] сообщений вверх, число просто взято "с запасом"
+         * fetch [messagesLookupCount] messages back though history
          */
-        private val messagesLookupCount = 100
+        private val messagesLookupCount = 25
 
         override fun sendMessage(message: SlackSendMessageRequest): Try<SlackMessage> {
 

--- a/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackClient.kt
+++ b/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackClient.kt
@@ -135,8 +135,9 @@ interface SlackClient : SlackMessageSender, SlackFileUploader {
                 }
         }
 
-        // Ищем ID канала по его имени
-        // Судя по https://stackoverflow.com/a/50114874/2893307 это единственный способ
+        /**
+         * https://stackoverflow.com/a/50114874/2893307
+         */
         private fun findChannelByName(name: String): Try<Channel> {
             val request = ChannelsListRequest.builder()
                 .token(token)
@@ -161,13 +162,13 @@ interface SlackClient : SlackMessageSender, SlackFileUploader {
 }
 
 private fun <T : SlackApiResponse> T.toTry(): Try<T> {
-    return if (this.isOk) {
+    return if (isOk) {
         Try.Success(this)
     } else {
         Try.Failure(
             RuntimeException(
-                "Slack request failed; error=${this.error} [needed=${this.needed}; " +
-                    "provided=${this.provided}]"
+                "Slack request failed; error=${error} [needed=${needed}; " +
+                    "provided=${provided}]"
             )
         )
     }

--- a/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackClient.kt
+++ b/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackClient.kt
@@ -166,10 +166,7 @@ private fun <T : SlackApiResponse> T.toTry(): Try<T> {
         Try.Success(this)
     } else {
         Try.Failure(
-            RuntimeException(
-                "Slack request failed; error=${error} [needed=${needed}; " +
-                    "provided=${provided}]"
-            )
+            RuntimeException("Slack request failed; error=$error [needed=$needed; provided=$provided]")
         )
     }
 }

--- a/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackConditionalSender.kt
+++ b/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackConditionalSender.kt
@@ -19,7 +19,7 @@ class SlackConditionalSender(
     override fun sendMessage(message: SlackSendMessageRequest): Try<SlackMessage> {
         logger.info(
             "[Slack] Sending message using SlackConditionalSender, " +
-                "trying to find previous message in channel=${message.channel}"
+                "trying to find previous message in channel: ${message.channel.name}"
         )
         return slackClient.findMessage(message.channel, condition)
             .fold(
@@ -30,8 +30,8 @@ class SlackConditionalSender(
                 { throwable ->
                     logger.info(
                         message = "[Slack] Previous message not found, " +
-                            "posting new one in channel=${message.channel}; " +
-                            "message=${SlackStringFormat.ellipsize(string = message.text, limit = 50)}",
+                            "posting new one to channel: ${message.channel.name}; " +
+                            "message: '${SlackStringFormat.ellipsize(string = message.text, limit = 50)}'",
                         error = throwable
                     )
                     slackClient.sendMessage(message)

--- a/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackMessageUpdaterWithThreadMark.kt
+++ b/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/SlackMessageUpdaterWithThreadMark.kt
@@ -21,8 +21,8 @@ class SlackMessageUpdaterWithThreadMark(
         newContent: String
     ): Try<SlackMessage> {
         logger.info(
-            "[Slack] Updating message with thread mark; channel=${previousMessage.channel}; " +
-                "oldMessage=${SlackStringFormat.ellipsize(string = previousMessage.text, limit = 50)}; "
+            "[Slack] Updating message with thread mark; channel: ${previousMessage.channel.name}; " +
+                "oldMessage: '${SlackStringFormat.ellipsize(string = previousMessage.text, limit = 50)}'; "
         )
         return slackClient.sendMessage(
             SlackSendMessageRequest(
@@ -34,8 +34,8 @@ class SlackMessageUpdaterWithThreadMark(
             )
         ).flatMap {
             logger.info(
-                "[Slack] Thread message posted; channel=${previousMessage.channel}; " +
-                    "threadId=${previousMessage.timestamp}; " +
+                "[Slack] Thread message posted; channel: ${previousMessage.channel.name}; " +
+                    "threadId: '${previousMessage.timestamp}'; " +
                     SlackStringFormat.ellipsize(string = threadMessage, limit = 50)
             )
 
@@ -48,7 +48,7 @@ class SlackMessageUpdaterWithThreadMark(
             .onSuccess {
                 logger.info(
                     "[Slack] Original message updated; " +
-                        "newMessage=${SlackStringFormat.ellipsize(string = newContent, limit = 50)}"
+                        "newMessage: '${SlackStringFormat.ellipsize(string = newContent, limit = 50)}'"
                 )
             }
     }

--- a/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/model/FoundMessage.kt
+++ b/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/model/FoundMessage.kt
@@ -2,9 +2,9 @@ package com.avito.slack.model
 
 data class FoundMessage(
     val text: String,
-    val botId: String,
+    val botId: String?,
     val timestamp: String,
-    val author: String,
+    val author: String?,
     val emoji: String?,
     val channel: SlackChannel
 ) {

--- a/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/model/SlackSendMessageRequest.kt
+++ b/subprojects/gradle/slack/src/main/kotlin/com/avito/slack/model/SlackSendMessageRequest.kt
@@ -3,12 +3,10 @@ package com.avito.slack.model
 data class SlackSendMessageRequest(
     val channel: SlackChannel,
     val text: String,
-    val author: String,
+    val author: String?,
     val emoji: String? = null,
     val threadId: String? = null
 ) {
 
-    override fun toString(): String {
-        return "Message "
-    }
+    override fun toString(): String = "Message "
 }


### PR DESCRIPTION
`username` and `botId` could be legally null
Integration test started to fail because some messages in integration test channel had empty author