### PR TITLE
Speedup UniqueRClasses build check

### DIFF
--- a/docs/content/docs/projects/BuildChecks.md
+++ b/docs/content/docs/projects/BuildChecks.md
@@ -321,7 +321,8 @@ buildChecks {
 ### Unique R classes
 
 If two Android modules use the same package, their R classes will be merged. 
-While merging, it can unexpectedly override resources. It happens even with `android.namespacedRClass`.
+While merging, it can unexpectedly override resources ([#175316324](https://issuetracker.google.com/issues/175316324)). 
+It happens even with `android.namespacedRClass`.
 
 To forbid merged R files use this check:
 
@@ -332,7 +333,6 @@ To forbid merged R files use this check:
 ```kotlin
 plugins {
     id("com.avito.android.buildchecks")
-    id("com.avito.android.impact") // this check requires impact analysis
 }
 
 buildChecks {
@@ -347,7 +347,6 @@ buildChecks {
 ```groovy
 plugins {
     id("com.avito.android.buildchecks")
-    id("com.avito.android.impact") // this check requires impact analysis
 }
 
 buildChecks {
@@ -357,6 +356,26 @@ buildChecks {
 
 {{< /tab >}}
 {{< /tabs >}}
+
+Try also `android.uniquePackageNames` check. In AGP 4.1 it provides similar but less complete contract.
+
+#### Configuration
+
+You can suppress errors for a specific package name:
+
+`build.gradle.kts`
+
+```kotlin
+buildChecks {
+    uniqueRClasses {
+        allowedNonUniquePackageNames.addAll(listOf(
+            "androidx.test", // Default from ManifestMerger #151171905
+            "androidx.test.espresso", // Won't fix: https://issuetracker.google.com/issues/176002058
+            "androidx.navigation.ktx" // Fixed in 2.2.1: https://developer.android.com/jetpack/androidx/releases/navigation#2.2.1
+        ))
+    }
+}
+```
 
 ### Gradle daemon reusage
 

--- a/subprojects/gradle/buildchecks/src/main/kotlin/com/avito/android/plugin/build_param_check/BuildChecksExtension.kt
+++ b/subprojects/gradle/buildchecks/src/main/kotlin/com/avito/android/plugin/build_param_check/BuildChecksExtension.kt
@@ -88,7 +88,9 @@ open class BuildChecksExtension {
             override var enabled: Boolean = false
         }
 
-        open class UniqueRClasses : Check()
+        open class UniqueRClasses : Check() {
+            val allowedNonUniquePackageNames: MutableList<String> = mutableListOf()
+        }
 
         open class IncrementalKapt : Check() {
             var mode: CheckMode = CheckMode.WARNING

--- a/subprojects/gradle/buildchecks/src/main/kotlin/com/avito/android/plugin/build_param_check/BuildParamCheckPlugin.kt
+++ b/subprojects/gradle/buildchecks/src/main/kotlin/com/avito/android/plugin/build_param_check/BuildParamCheckPlugin.kt
@@ -121,16 +121,8 @@ open class BuildParamCheckPlugin : Plugin<Project> {
             }
         }
         if (checks.hasInstance<Check.UniqueRClasses>()) {
-            check(project.pluginManager.hasPlugin("com.avito.android.impact")) {
-                "build check 'uniqueRClasses' requires 'com.avito.android.impact' plugin"
-            }
-            val task = project.tasks.register<UniqueRClassesTask>("checkUniqueAndroidPackages") {
-                group = "verification"
-                description = "Verify unique R classes"
-            }
-            checkBuildEnvironment {
-                dependsOn(task)
-            }
+            UniqueRClassesTaskFactory(project, checks.getInstance())
+                .register(checkBuildEnvironment)
         }
         if (checks.hasInstance<Check.MacOSLocalhost>() && isMac()) {
             val task = project.tasks.register<MacOSLocalhostResolvingTask>("checkMacOSLocalhostResolving") {

--- a/subprojects/gradle/buildchecks/src/main/kotlin/com/avito/android/plugin/build_param_check/UniqueRClassesTask.kt
+++ b/subprojects/gradle/buildchecks/src/main/kotlin/com/avito/android/plugin/build_param_check/UniqueRClassesTask.kt
@@ -1,43 +1,83 @@
 package com.avito.android.plugin.build_param_check
 
-import com.avito.android.isAndroid
 import com.avito.android.isAndroidApp
-import com.avito.impact.configuration.internalModule
-import com.avito.impact.util.AndroidManifest
+import com.avito.impact.util.AndroidManifestPackageParser
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
 
-abstract class UniqueRClassesTask : DefaultTask() {
+@CacheableTask
+abstract class UniqueRClassesTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val appManifest: RegularFileProperty
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val librariesManifests: Property<FileCollection>
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val testManifests: Property<FileCollection>
+
+    @Input
+    val allowedNonUniquePackageNames: ListProperty<String> = objects.listProperty(String::class.java)
+
+    @OutputFile
+    val output: Property<RegularFile> = objects.fileProperty().apply {
+        set(project.layout.buildDirectory.file("${UniqueRClassesTask::class.java.simpleName}.output"))
+    }
 
     @TaskAction
     fun check() {
-        val apps = project.subprojects.filter { it.isAndroidApp() }
+        check(project.isAndroidApp()) {
+            "${project.path} must be an Android application module"
+        }
 
-        apps.stream().parallel().forEach { app ->
-            val packages: List<String> = app.internalModule
-                .configurations.flatMap {
-                    it.allDependencies(includeSelf = false)
-                }
-                .toSet()
-                .filter { it.module.project.isAndroid() }
-                .map {
-                    AndroidManifest.from(it.module.project).getPackage()
-                }
+        val packages: List<String> = librariesManifests.get().files
+            .asSequence()
+            .plus(appManifest.get().asFile)
+            .plus(testManifests.get().files)
+            .toSet()
+            .map {
+                requireNotNull(AndroidManifestPackageParser.parse(it))
+            }
+            .toMutableList()
+            .filter { packageName ->
+                !allowedNonUniquePackageNames.get().contains(packageName)
+            }
+            .toList()
 
-            val duplicates = packages.duplicates()
-            if (duplicates.isNotEmpty()) {
-                throw IllegalStateException(
-                    FailedCheckMessage(
-                        BuildChecksExtension::uniqueRClasses,
-                        """
-                    Application ${app.path} has modules with the same package: $duplicates.
+        val duplicates = packages.duplicates()
+        if (duplicates.isNotEmpty()) {
+            throw IllegalStateException(
+                FailedCheckMessage(
+                    BuildChecksExtension::uniqueRClasses,
+                    """
+                    Application ${project.path} has modules with the same package: $duplicates.
                     It leads to unexpected resource overriding.
                     Please, make packages unique.
                     """
-                    ).toString()
-                )
-            }
+                ).toString()
+            )
         }
+
+        output.get().asFile.writeText("1")
     }
 
     private fun <T> List<T>.duplicates(): Set<T> {

--- a/subprojects/gradle/buildchecks/src/main/kotlin/com/avito/android/plugin/build_param_check/UniqueRClassesTaskFactory.kt
+++ b/subprojects/gradle/buildchecks/src/main/kotlin/com/avito/android/plugin/build_param_check/UniqueRClassesTaskFactory.kt
@@ -1,0 +1,63 @@
+package com.avito.android.plugin.build_param_check
+
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+import com.android.build.gradle.tasks.ProcessApplicationManifest
+import com.android.build.gradle.tasks.ProcessTestManifest
+import com.avito.android.androidAppExtension
+import com.avito.android.isAndroidApp
+import com.avito.android.plugin.build_param_check.BuildChecksExtension.Check
+import com.avito.kotlin.dsl.isRoot
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.register
+
+internal class UniqueRClassesTaskFactory(
+    private val rootProject: Project,
+    private val config: Check.UniqueRClasses
+) {
+
+    init {
+        check(rootProject.isRoot()) {
+            "Project ${rootProject.path} must be root"
+        }
+    }
+
+    fun register(rootTask: TaskProvider<Task>) {
+        rootProject.subprojects.forEach { module ->
+            module.pluginManager.withPlugin("com.android.application") {
+
+                module.androidAppExtension.applicationVariants.all { appVariant ->
+                    rootTask.dependsOn(
+                        register(module, appVariant)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun register(project: Project, appVariant: ApplicationVariant): TaskProvider<UniqueRClassesTask> {
+        check(project.isAndroidApp()) {
+            "Project ${project.path} must be an Android application module"
+        }
+        return project.tasks.register<UniqueRClassesTask>("checkUniqueAndroidPackages${appVariant.name.capitalize()}") {
+            group = "verification"
+            description = "Verify unique R classes"
+
+            allowedNonUniquePackageNames.set(config.allowedNonUniquePackageNames)
+
+            val processAppManifest = project.tasks.withType(ProcessApplicationManifest::class.java)
+                .first { it.variantName == appVariant.name }
+
+            val processTestManifest = project.tasks.withType(ProcessTestManifest::class.java).first()
+
+            appManifest.set(processAppManifest.mergedManifest)
+            librariesManifests.set(processAppManifest.getManifests())
+            testManifests.set(processTestManifest.getManifests())
+
+            dependsOn(processAppManifest)
+            dependsOn(processTestManifest)
+        }
+    }
+}


### PR DESCRIPTION
Build check for [unique package names](https://avito-tech.github.io/avito-android/docs/projects/buildchecks/#unique-r-classes) (R classes) was too slow. It took ~3min for Avito application.
The problem is in impact analysis. To find all manifests to merge we had to resolve all dependencies.
For now, we can't do impact analysis inside Gradle workers.

I've switched to consuming manifests directly from merging tasks. 
It gives caching and mostly instant execution - up to 0.1s for the check itself. Merging manifests also fast.