### PR TITLE
update android-builder image

### DIFF
--- a/_main.sh
+++ b/_main.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 source "$DIR"/ci/_environment.sh
 
@@ -94,14 +94,13 @@ function runInBuilder() {
     COMMANDS=$@
 
     docker run --rm \
-    --volume "$(pwd)":/app \
-    --volume /var/run/docker.sock:/var/run/docker.sock \
-    --volume "${GRADLE_CACHE_DIR}":/gradle/caches \
-    --volume "${GRADLE_WRAPPER_DIR}":/gradle/wrapper \
-    --workdir /app \
-    --env GRADLE_USER_HOME=/gradle \
-    --env LOCAL_USER_ID="$USER_ID" \
-    --env BINTRAY_GPG_PASSPHRASE="$BINTRAY_GPG_PASSPHRASE" \
-    ${IMAGE_ANDROID_BUILDER} \
-    bash -c "${GIT_COMMANDS} ${COMMANDS}"
+        --volume "$(pwd)":/app \
+        --volume /var/run/docker.sock:/var/run/docker.sock \
+        --volume "${GRADLE_CACHE_DIR}":/gradle/caches \
+        --volume "${GRADLE_WRAPPER_DIR}":/gradle/wrapper \
+        --workdir /app \
+        --env LOCAL_USER_ID="$USER_ID" \
+        --env BINTRAY_GPG_PASSPHRASE="$BINTRAY_GPG_PASSPHRASE" \
+        ${IMAGE_ANDROID_BUILDER} \
+        bash -c "${GIT_COMMANDS} ${COMMANDS}"
 }

--- a/ci/_environment.sh
+++ b/ci/_environment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ANDROID_BUILDER_TAG=c0de63a4ce
+ANDROID_BUILDER_TAG=334a3381e7
 
 if [[ -z "${DOCKER_REGISTRY+x}" ]]; then
     # using dockerhub for public availability

--- a/ci/docker/android-builder/Dockerfile
+++ b/ci/docker/android-builder/Dockerfile
@@ -23,30 +23,24 @@ ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
 
 # ----------------- Android SDK -----------------
 ENV ANDROID_HOME /opt/android-sdk
-ENV PATH ${PATH}:${ANDROID_HOME}/tools/:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/platform-tools/bin:${ANDROID_HOME}/tools/bin
+ENV PATH ${PATH}:${ANDROID_HOME}/tools/:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/platform-tools/bin:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/cmdline-tools/bin
 # https://developer.android.com/studio/index.html#command-tools
-ARG ANDROID_SDK_URL=https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
+ARG ANDROID_SDK_URL=https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip
 ARG ANDROID_SDK_FILE_NAME=android-sdk.zip
 
 RUN curl $ANDROID_SDK_URL --progress-bar --location --output $ANDROID_SDK_FILE_NAME && \
   unzip $ANDROID_SDK_FILE_NAME -d $ANDROID_HOME && \
   rm -f $ANDROID_SDK_FILE_NAME
 
+COPY packages.txt $ANDROID_HOME/packages.txt
+
 # Update sdk and install components
-# --package_file is broken https://issuetracker.google.com/issues/66465833
 RUN mkdir $HOME/.android && \
-  # empty file to mitigate warning
-  touch $HOME/.android/repositories.cfg && \
   echo "y" | sdkmanager --verbose \
-    --sdk_root=${ANDROID_HOME} \
-    "build-tools;29.0.3" \
-    "patcher;v4" \
-    "platform-tools" \
-    "platforms;android-29" \
-    "tools" \
-    "extras;google;google_play_services" \
-    "extras;google;m2repository" && \
-  chmod -R o+rwX ${ANDROID_HOME}
+    --sdk_root=$ANDROID_HOME \
+    --package_file=$ANDROID_HOME/packages.txt && \
+  chmod -R o+rwX $ANDROID_HOME && \
+  rm $ANDROID_HOME/packages.txt
 
 # --------------- Gradle Profiler -----------------
 # https://github.com/gradle/gradle-profiler/releases
@@ -55,7 +49,8 @@ ARG PROFILER_VERSION=0.15.0
 # Install gradle-profiler
 RUN \
   cd /opt/ && \
-  curl https://repo.gradle.org/gradle/ext-releases-local/org/gradle/profiler/gradle-profiler/${PROFILER_VERSION}/gradle-profiler-${PROFILER_VERSION}.zip --progress-bar --location --output gradle-profiler.zip && \
+  curl https://repo.gradle.org/gradle/ext-releases-local/org/gradle/profiler/gradle-profiler/${PROFILER_VERSION}/gradle-profiler-${PROFILER_VERSION}.zip \
+    --progress-bar --location --output gradle-profiler.zip && \
   unzip gradle-profiler.zip && \
   mv gradle-profiler-${PROFILER_VERSION} gradle-profiler && \
   cp -a gradle-profiler/. /usr/local/ && \

--- a/ci/docker/android-builder/entrypoint.sh
+++ b/ci/docker/android-builder/entrypoint.sh
@@ -6,6 +6,7 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 BUILD_USER=build_user
+GRADLE_USER_HOME=/gradle
 
 echo "Starting with UID : $USER_ID"
 groupadd --gid "${USER_ID}" ${BUILD_USER}

--- a/ci/docker/android-builder/packages.txt
+++ b/ci/docker/android-builder/packages.txt
@@ -1,0 +1,6 @@
+build-tools;30.0.3
+build-tools;29.0.3
+platforms;android-29
+tools
+extras;google;google_play_services
+extras;google;m2repository


### PR DESCRIPTION
key changes:
 - build-tools;30.0.3 (kept 29.0.3 for migration)
 - updated commandline tools (installs in another location, fixed package_file parameter, installs patcher and platform-tools by default)
 - no need to pass ENV GRADLE_USER_HOME anymore

https://hub.docker.com/layers/avitotech/android-builder/334a3381e7/images/sha256-c9582e9f344a38d047e87bf6d3709c91c8802ae9e6d0e2aba674c1bdd5320fcf?context=explore