### PR TITLE
MBS-9285 use system properties to align versions

### DIFF
--- a/buildscript/src/main/kotlin/Dependencies.kt
+++ b/buildscript/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,6 @@ object Dependencies {
         const val mockito = "3.3.3"
         const val detekt = "1.10.0"
         const val coroutines = "1.3.7"
-        const val androidGradlePlugin: String = "4.1.1"
     }
 
     const val kotlinXCli = "org.jetbrains.kotlinx:kotlinx-cli:0.2.1"
@@ -72,7 +71,6 @@ object Dependencies {
     const val freeReflection = "me.weishu:free_reflection:2.2.0"
 
     object Gradle {
-        const val androidPlugin = "com.android.tools.build:gradle:${Versions.androidGradlePlugin}"
         const val kotlinPlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin"
 
         object Avito {

--- a/subprojects/build.gradle.kts
+++ b/subprojects/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     id("com.android.application") apply false
     id("com.jfrog.bintray") version "1.8.4" apply false
     id("com.autonomousapps.dependency-analysis") apply false
-    id("io.gitlab.arturbosch.detekt") version "1.15.0"
+    id("io.gitlab.arturbosch.detekt")
 }
 
 if (gradle.startParameter.taskNames.contains("buildHealth")) {
@@ -66,8 +66,12 @@ val finalProjectVersion: String = System.getProperty("avito.project.version").le
     if (env.isNullOrBlank()) projectVersion else env
 }
 
+val kotlinVersion = providers.systemProperty("kotlinVersion").forUseAtConfigurationTime()
+val detektVersion = providers.systemProperty("detektVersion").forUseAtConfigurationTime()
+val androidGradlePluginVersion = providers.systemProperty("androidGradlePluginVersion").forUseAtConfigurationTime()
+
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.15.0-RC1")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${detektVersion.get()}")
 }
 
 subprojects {
@@ -209,7 +213,7 @@ subprojects {
             }
 
             dependencies {
-                "implementation"(Dependencies.kotlinStdlib)
+                "api"(platform("org.jetbrains.kotlin:kotlin-bom:${kotlinVersion.get()}"))
                 "api"(platform("com.squareup.okhttp3:okhttp-bom:4.9.0"))
             }
         }
@@ -233,7 +237,7 @@ subprojects {
                 systemProperty("kotlinVersion", plugins.getPlugin(KotlinPluginWrapper::class.java).kotlinPluginVersion)
                 systemProperty("compileSdkVersion", compileSdk)
                 systemProperty("buildToolsVersion", buildTools)
-                systemProperty("androidGradlePluginVersion", Dependencies.Versions.androidGradlePlugin)
+                systemProperty("androidGradlePluginVersion", androidGradlePluginVersion.get())
 
                 /**
                  * IDEA добавляет специальный init script, по нему понимаем что запустили в IDE

--- a/subprojects/gradle.properties
+++ b/subprojects/gradle.properties
@@ -18,3 +18,7 @@ android.useAndroidX=true
 projectVersion=2021.3
 # Disable console output https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/202
 systemProp.dependency.analysis.silent=true
+# Versions
+systemProp.kotlinVersion=1.4.21
+systemProp.detektVersion=1.15.0
+systemProp.androidGradlePluginVersion=4.1.1

--- a/subprojects/gradle/android/build.gradle.kts
+++ b/subprojects/gradle/android/build.gradle.kts
@@ -4,8 +4,11 @@ plugins {
     id("com.jfrog.bintray")
 }
 
+@Suppress("UnstableApiUsage")
+val androidGradlePluginVersion = providers.systemProperty("androidGradlePluginVersion").forUseAtConfigurationTime()
+
 dependencies {
-    api(Dependencies.Gradle.androidPlugin) {
+    api("com.android.tools.build:gradle:${androidGradlePluginVersion.get()}") {
         excludeTransitiveAgpDependencies()
     }
 

--- a/subprojects/settings.gradle.kts
+++ b/subprojects/settings.gradle.kts
@@ -146,21 +146,28 @@ pluginManagement {
         }
     }
 
+    val kotlinVersion = providers.systemProperty("kotlinVersion").forUseAtConfigurationTime()
+    val detektVersion = providers.systemProperty("detektVersion").forUseAtConfigurationTime()
+    val androidGradlePluginVersion = providers.systemProperty("androidGradlePluginVersion").forUseAtConfigurationTime()
+
     resolutionStrategy {
         eachPlugin {
             val pluginId = requested.id.id
             when {
                 pluginId.startsWith("com.android.") ->
-                    useModule("com.android.tools.build:gradle:4.1.1")
+                    useModule("com.android.tools.build:gradle:${androidGradlePluginVersion.get()}")
 
                 pluginId.startsWith("org.jetbrains.kotlin.") ->
-                    useVersion("1.4.21")
+                    useVersion(kotlinVersion.get())
 
                 pluginId == "com.autonomousapps.dependency-analysis" ->
                     useVersion("0.55.0")
 
                 pluginId == "nebula.integtest" ->
                     useVersion("8.0.0")
+
+                pluginId == "io.gitlab.arturbosch.detekt" ->
+                    useVersion(detektVersion.get())
             }
         }
     }


### PR DESCRIPTION
use system properties to align versions between plugins and dependencies for kotlin, agp and detekt

use kotlin bom to achieve same version for all kotlin dependencies

use forUseAtConfigurationTime to read system properties and not break configuration cache