### PR TITLE
AGP 4.2 

### DIFF
--- a/build-logic/android-convention/src/main/kotlin/convention.kotlin-android-library.gradle.kts
+++ b/build-logic/android-convention/src/main/kotlin/convention.kotlin-android-library.gradle.kts
@@ -10,6 +10,12 @@ plugins {
 
 val generatedJavaResDir = project.layout.buildDirectory.file("generated/avito/java_res")
 
+androidComponents {
+    beforeAndroidTests {
+        it.enabled = false
+    }
+}
+
 android {
 
     /**
@@ -19,13 +25,6 @@ android {
     variantFilter {
         if (name != "release") {
             ignore = true
-        }
-    }
-
-    @Suppress("UnstableApiUsage")
-    onVariants {
-        androidTest {
-            enabled = false
         }
     }
 

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -65,7 +65,7 @@ dependencyResolutionManagement {
                 includeModuleByRegex("com\\.android.*", "(?!r8).*")
                 includeModuleByRegex("com\\.google\\.android.*", ".*")
                 includeGroupByRegex("androidx\\..*")
-                includeGroup("com.google.test.platform")
+                includeGroup("com.google.testing.platform")
             }
         }
 

--- a/libraries/src/main/kotlin/com/avito/android/ExternalLibrariesExtension.kt
+++ b/libraries/src/main/kotlin/com/avito/android/ExternalLibrariesExtension.kt
@@ -32,7 +32,7 @@ abstract class ExternalLibrariesExtension @Inject constructor(private val provid
      * We use exact version to provide consistent environment and avoid build cache issues
      * (AGP tasks has artifacts from build tools)
      */
-    val buildToolsVersion = "29.0.3"
+    val buildToolsVersion = "30.0.3"
 
     val androidGradlePluginVersion = systemProperty("androidGradlePluginVersion").get()
     val androidLintVersion = systemProperty("androidLintVersion").get()

--- a/subprojects/gradle.properties
+++ b/subprojects/gradle.properties
@@ -27,7 +27,7 @@ systemProp.dependency.analysis.silent=true
 # Versions
 # System property used instead of Gradle, because Gradle properties are not passed to included builds: https://github.com/gradle/gradle/issues/2534
 systemProp.kotlinVersion=1.4.32
-systemProp.androidGradlePluginVersion=4.1.2
+systemProp.androidGradlePluginVersion=4.2.0
 # lint/tools version = AGP version + 23.0.0
 systemProp.androidLintVersion=27.1.2
 systemProp.detektVersion=1.16.0

--- a/subprojects/gradle/android/src/main/kotlin/com/avito/android/ProjectExtensions.kt
+++ b/subprojects/gradle/android/src/main/kotlin/com/avito/android/ProjectExtensions.kt
@@ -3,7 +3,7 @@
 package com.avito.android
 
 import com.android.build.api.component.ComponentIdentity
-import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.extension.AndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.BaseExtension
@@ -35,8 +35,9 @@ fun Project.withAndroidModule(block: (testedExtension: TestedExtension) -> Unit)
 }
 
 @Suppress("UnstableApiUsage")
-val Project.androidCommonExtension: CommonExtension<*, *, *, *, *, *, *, *>
-    get() = extensions.getByType(CommonExtension::class.java)
+fun Project.androidComponents(block: AndroidComponentsExtension<*, *>.() -> Unit) {
+    block(extensions.getByType(AndroidComponentsExtension::class.java))
+}
 
 val Project.androidBaseExtension: BaseExtension
     get() = extensions.getByName<BaseExtension>("android")

--- a/subprojects/settings.gradle.kts
+++ b/subprojects/settings.gradle.kts
@@ -285,7 +285,7 @@ dependencyResolutionManagement {
                 includeModuleByRegex("com\\.android.*", "(?!r8).*")
                 includeModuleByRegex("com\\.google\\.android.*", ".*")
                 includeGroupByRegex("androidx\\..*")
-                includeGroup("com.google.test.platform")
+                includeGroup("com.google.testing.platform")
             }
         }
         exclusiveContent {

--- a/subprojects/signer/src/main/kotlin/com/avito/plugin/SigningResolver.kt
+++ b/subprojects/signer/src/main/kotlin/com/avito/plugin/SigningResolver.kt
@@ -11,7 +11,7 @@ import org.gradle.api.provider.Provider
 internal class SigningResolver(
     private val project: Project,
     private val extension: SignExtension,
-    private val variant: Variant<*>,
+    private val variant: Variant,
     private val signTokensMap: Map<String, String?>,
 ) {
 


### PR DESCRIPTION
https://developer.android.com/studio/releases/gradle-plugin#4-2-0

## TODO

### Failing tests in signer plugin
```
Circular dependency between the following tasks:
:app:bundleRelease
+--- :app:produceReleaseBundleIdeListingFile
|    \--- :app:signBundleViaServiceRelease
|         \--- :app:bundleRelease (*)
\--- :app:signBundleViaServiceRelease (*)
```

### Failed to apply plugin 'com.android.internal.application' in multiple tests 

https://github.com/gradle/gradle/issues/16774

Using in memory project generator https://github.com/avito-tech/avito-android/blob/752fbc219b69352e6aa7a00f81126bfed3daadd9/subprojects/gradle/test-project/src/main/kotlin/com/avito/test/gradle/InMemoryProjectGenerator.kt

Could not create plugin of type 'AppPlugin'

Cannot create service of type DefaultBuildEventsListenerRegistry using DefaultBuildEventsListenerRegistry constructor as required service of type BuildEventListenerFactory for parameter #1 is not available.

