### PR TITLE
MBS-9048 filter critical log level

### DIFF
--- a/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/AndroidLoggerFactory.kt
+++ b/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/AndroidLoggerFactory.kt
@@ -12,12 +12,16 @@ import com.avito.logger.handler.LoggingHandler
 
 class AndroidLoggerFactory(
     private val elasticConfig: ElasticConfig,
-    private val sentryConfig: SentryConfig
+    private val sentryConfig: SentryConfig,
+    private val testName: String?
 ) : LoggerFactory {
 
     override fun create(tag: String): Logger {
 
-        val metadata = AndroidMetadata(tag)
+        val metadata = AndroidTestMetadata(
+            tag = tag,
+            testName = testName
+        )
 
         val defaultHandler = defaultHandler(metadata)
 
@@ -29,7 +33,7 @@ class AndroidLoggerFactory(
         )
     }
 
-    private fun defaultHandler(metadata: AndroidMetadata): LoggingHandler {
+    private fun defaultHandler(metadata: AndroidTestMetadata): LoggingHandler {
         return if (elasticConfig is ElasticConfig.Enabled) {
             CombinedHandler(
                 listOf(
@@ -42,15 +46,15 @@ class AndroidLoggerFactory(
         }
     }
 
-    private fun androidLogHandler(metadata: AndroidMetadata): LoggingHandler {
+    private fun androidLogHandler(metadata: AndroidTestMetadata): LoggingHandler {
         return DefaultLoggingHandler(destination = AndroidLogDestination(metadata))
     }
 
-    private fun elasticHandler(metadata: AndroidMetadata): LoggingHandler {
+    private fun elasticHandler(metadata: AndroidTestMetadata): LoggingHandler {
         return DefaultLoggingHandler(destination = ElasticDestinationFactory.create(elasticConfig, metadata))
     }
 
-    private fun criticalHandler(defaultHandler: LoggingHandler, metadata: AndroidMetadata): LoggingHandler {
+    private fun criticalHandler(defaultHandler: LoggingHandler, metadata: AndroidTestMetadata): LoggingHandler {
         return if (sentryConfig is SentryConfig.Enabled) {
             val sentryHandler =
                 DefaultLoggingHandler(

--- a/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/AndroidMetadata.kt
+++ b/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/AndroidMetadata.kt
@@ -1,8 +1,0 @@
-package com.avito.android.log
-
-internal data class AndroidMetadata(val tag: String) {
-
-    fun toMap(): Map<String, String> {
-        return mapOf("tag" to tag)
-    }
-}

--- a/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/AndroidTestMetadata.kt
+++ b/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/AndroidTestMetadata.kt
@@ -1,0 +1,17 @@
+package com.avito.android.log
+
+internal data class AndroidTestMetadata(
+    val tag: String,
+    val testName: String?
+) {
+
+    fun toMap(): Map<String, String> {
+        val result = mutableMapOf("tag" to tag)
+
+        if (!testName.isNullOrBlank()) {
+            result["test_name"] = testName
+        }
+
+        return result
+    }
+}

--- a/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/ElasticDestinationFactory.kt
+++ b/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/ElasticDestinationFactory.kt
@@ -6,7 +6,7 @@ import com.avito.logger.destination.ElasticDestination
 
 internal object ElasticDestinationFactory {
 
-    fun create(config: ElasticConfig, metadata: AndroidMetadata): LoggingDestination {
+    fun create(config: ElasticConfig, metadata: AndroidTestMetadata): LoggingDestination {
         return ElasticDestination(
             config = config,
             metadata = metadata.toMap()

--- a/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/SentryDestinationFactory.kt
+++ b/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/SentryDestinationFactory.kt
@@ -6,7 +6,7 @@ import com.avito.logger.destination.SentryDestination
 
 internal object SentryDestinationFactory {
 
-    fun create(config: SentryConfig, metadata: AndroidMetadata): LoggingDestination {
+    fun create(config: SentryConfig, metadata: AndroidTestMetadata): LoggingDestination {
         return SentryDestination(config, metadata.toMap())
     }
 }

--- a/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/destination/AndroidLogDestination.kt
+++ b/subprojects/android-test/android-log/src/main/kotlin/com/avito/android/log/destination/AndroidLogDestination.kt
@@ -1,18 +1,18 @@
 package com.avito.android.log.destination
 
 import android.util.Log
-import com.avito.android.log.AndroidMetadata
+import com.avito.android.log.AndroidTestMetadata
 import com.avito.logger.LogLevel
 import com.avito.logger.LoggingDestination
 
-internal class AndroidLogDestination(private val androidMetadata: AndroidMetadata) : LoggingDestination {
+internal class AndroidLogDestination(private val metadata: AndroidTestMetadata) : LoggingDestination {
 
     override fun write(level: LogLevel, message: String, throwable: Throwable?) {
         when (level) {
-            LogLevel.DEBUG -> Log.d(androidMetadata.tag, message, throwable)
-            LogLevel.INFO -> Log.i(androidMetadata.tag, message, throwable)
-            LogLevel.WARNING -> Log.w(androidMetadata.tag, message, throwable)
-            LogLevel.CRITICAL -> Log.e(androidMetadata.tag, message, throwable)
+            LogLevel.DEBUG -> Log.d(metadata.tag, message, throwable)
+            LogLevel.INFO -> Log.i(metadata.tag, message, throwable)
+            LogLevel.WARNING -> Log.w(metadata.tag, message, throwable)
+            LogLevel.CRITICAL -> Log.e(metadata.tag, message, throwable)
         }
     }
 }

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/monitoring/CompositeTestIssuesMonitor.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/monitoring/CompositeTestIssuesMonitor.kt
@@ -66,7 +66,7 @@ class CompositeTestIssuesMonitor(
         return EventBuilder()
             .withTag(
                 "test_name",
-                "${testRunEnvironment.testMetadata.className}.${testRunEnvironment.testMetadata.methodName}"
+                testRunEnvironment.testMetadata.testName
             )
             .withTag("build_id", testRunEnvironment.teamcityBuildId.toString())
             .withTag("build_branch", testRunEnvironment.buildBranch)

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
@@ -81,9 +81,11 @@ abstract class InHouseInstrumentationTestRunner :
     val testRunEnvironment: TestRunEnvironment by lazy { createRunnerEnvironment(instrumentationArguments) }
 
     override val loggerFactory by lazy {
+        val runEnvironment = testRunEnvironment.asRunEnvironmentOrThrow()
         AndroidLoggerFactory(
             elasticConfig = elasticConfig,
-            sentryConfig = sentryConfig
+            sentryConfig = sentryConfig,
+            testName = runEnvironment.testMetadata.testName
         )
     }
 
@@ -310,7 +312,7 @@ abstract class InHouseInstrumentationTestRunner :
      */
     private fun initApplicationCrashHandling() {
         val currentHandler = Thread.getDefaultUncaughtExceptionHandler()
-        
+
         Thread.setDefaultUncaughtExceptionHandler(
             ReportUncaughtHandler(
                 loggerFactory = loggerFactory,

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
@@ -292,7 +292,7 @@ abstract class InHouseInstrumentationTestRunner :
             report.registerIncident(AppCrashException(incident))
             report.reportTestCase()
         } catch (t: Throwable) {
-            logger.warn("Can't register and report unexpected incident", t)
+            logger.critical("Can't register and report unexpected incident", t)
         }
     }
 
@@ -309,8 +309,14 @@ abstract class InHouseInstrumentationTestRunner :
      * глобальном обработчике.
      */
     private fun initApplicationCrashHandling() {
+        val currentHandler = Thread.getDefaultUncaughtExceptionHandler()
+        
         Thread.setDefaultUncaughtExceptionHandler(
-            ReportUncaughtHandler(loggerFactory)
+            ReportUncaughtHandler(
+                loggerFactory = loggerFactory,
+                globalExceptionHandler = currentHandler,
+                nonCriticalErrorMessages = setOf("Error while disconnecting UiAutomation")
+            )
         )
     }
 

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/ReportUncaughtHandler.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/ReportUncaughtHandler.kt
@@ -5,18 +5,19 @@ import com.avito.logger.create
 
 internal class ReportUncaughtHandler(
     loggerFactory: LoggerFactory,
-    private val globalExceptionHandler: Thread.UncaughtExceptionHandler? = Thread.getDefaultUncaughtExceptionHandler()
+    private val globalExceptionHandler: Thread.UncaughtExceptionHandler?,
+    private val nonCriticalErrorMessages: Set<String>
 ) : Thread.UncaughtExceptionHandler {
 
     private val logger = loggerFactory.create<ReportUncaughtHandler>()
 
     override fun uncaughtException(t: Thread, e: Throwable) {
-        logger.critical("Application crash captured by global handler", e)
-
-        InHouseInstrumentationTestRunner.instance.tryToReportUnexpectedIncident(
-            incident = e
-        )
-
-        globalExceptionHandler?.uncaughtException(t, e)
+        if (e.message in nonCriticalErrorMessages) {
+            logger.warn("Non critical error caught by ReportUncaughtHandler", e)
+        } else {
+            logger.critical("Application crash captured by global handler", e)
+            InHouseInstrumentationTestRunner.instance.tryToReportUnexpectedIncident(incident = e)
+            globalExceptionHandler?.uncaughtException(t, e)
+        }
     }
 }

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/ReportUncaughtHandler.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/ReportUncaughtHandler.kt
@@ -15,7 +15,7 @@ internal class ReportUncaughtHandler(
         if (e.message in nonCriticalErrorMessages) {
             logger.warn("Non critical error caught by ReportUncaughtHandler", e)
         } else {
-            logger.critical("Application crash captured by global handler", e)
+            logger.critical("Application crashed", e)
             InHouseInstrumentationTestRunner.instance.tryToReportUnexpectedIncident(incident = e)
             globalExceptionHandler?.uncaughtException(t, e)
         }

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/annotation/resolver/ImitationModeResolver.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/annotation/resolver/ImitationModeResolver.kt
@@ -11,7 +11,8 @@ class ImitationModeResolver : TestMetadataResolver {
 
     private val logger = AndroidLoggerFactory(
         elasticConfig = ElasticConfig.Disabled,
-        sentryConfig = SentryConfig.Disabled
+        sentryConfig = SentryConfig.Disabled,
+        testName = null
     ).create<ImitationModeResolver>()
 
     override val key: String = BUNDLE_KEY

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/test/AbstractLaunchRule.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/test/AbstractLaunchRule.kt
@@ -35,7 +35,7 @@ abstract class AbstractLaunchRule : TestRule {
                 beforeTest()
                 base.evaluate()
             } catch (t: Throwable) {
-                logger.critical("Error during test completion", t)
+                logger.warn("Error during test completion", t)
                 throw t
             }
         }

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/test/AbstractLaunchRule.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/test/AbstractLaunchRule.kt
@@ -35,7 +35,7 @@ abstract class AbstractLaunchRule : TestRule {
                 beforeTest()
                 base.evaluate()
             } catch (t: Throwable) {
-                logger.warn("Error during test completion", t)
+                logger.warn("Test execution failed", t)
                 throw t
             }
         }

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/ReportTestListener.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/ReportTestListener.kt
@@ -11,9 +11,11 @@ import org.junit.runner.notification.RunListener
 class ReportTestListener : RunListener() {
 
     private val report: Report by lazy { TestExecutionState.reportInstance }
+
     private val logger = AndroidLoggerFactory(
         elasticConfig = ElasticConfig.Disabled,
-        sentryConfig = SentryConfig.Disabled
+        sentryConfig = SentryConfig.Disabled,
+        testName = null
     ).create<ReportTestListener>()
 
     override fun testStarted(description: Description) {

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/Step.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/Step.kt
@@ -54,7 +54,7 @@ inline fun <T : DataSet> dataSet(
         dataSet = value
         // todo почему -1 это вообще валидное значение? попробовать использовать unsigned тип данных
         require(testMetadata.dataSetNumber != null && testMetadata.dataSetNumber != -1) {
-            "Please specify @DataSetNumber(Int) for test ${testMetadata.className}.${testMetadata.methodName}"
+            "Please specify @DataSetNumber(Int) for test ${testMetadata.testName}"
         }
     }
     action(value)

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/model/TestMetadata.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/model/TestMetadata.kt
@@ -19,4 +19,7 @@ data class TestMetadata(
     val featureIds: List<Int>,
     val tagIds: List<Int>,
     val flakiness: Flakiness
-) : Serializable
+) : Serializable {
+
+    val testName = "$className.$methodName"
+}

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/video/VideoCaptureTestListener.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/video/VideoCaptureTestListener.kt
@@ -76,7 +76,7 @@ class VideoCaptureTestListener(
                     logger.warn(
                         "Video uploading enabled. " +
                             "Failed to upload video for " +
-                            "${state.testMetadata.className}.${state.testMetadata.methodName}. " +
+                            "${state.testMetadata.testName}. " +
                             "Reason: ${result.message}",
                         result.error
                     )


### PR DESCRIPTION
- don't report every test error in AbstractLaunchRule
- don't report "Error while disconnecting UI Automation"
- report Can't register and report unexpected incident