### PR TITLE
MBS-10675 skip lambda toString reflection

### DIFF
--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/transport/ExternalStorageTransport.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/transport/ExternalStorageTransport.kt
@@ -36,11 +36,14 @@ class ExternalStorageTransport(
                     file.writeText(json)
                     logger.info("Wrote report for test to file: ${file.absolutePath}")
                 } catch (e: Throwable) {
-                    logger.warn("Can't write report runtime data; leads to LOST test", e)
+                    logger.critical("Can't write report runtime data; leads to LOST test", e)
                 }
 
             is Error ->
-                logger.warn("Can't create output file for test runtime data; leads to LOST test", outputFileResult.e)
+                logger.critical(
+                    "Can't create output file for test runtime data; leads to LOST test",
+                    outputFileResult.e
+                )
         }
     }
 }

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/transport/PreTransportMappers.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/transport/PreTransportMappers.kt
@@ -2,7 +2,9 @@ package com.avito.android.test.report.transport
 
 import com.avito.android.test.report.model.DataSet
 import com.avito.android.test.report.model.StepResult
+import com.avito.android.util.isLambda
 import com.avito.report.model.Step
+import java.lang.reflect.Field
 
 internal interface PreTransportMappers {
 
@@ -20,12 +22,15 @@ internal interface PreTransportMappers {
     fun DataSet.serialize(): Map<String, String> {
         return javaClass.declaredFields
             .filter { it.name != "number" }
-            .map { field ->
-                field.name to javaClass.methods
-                    .find { it.name == "get${field.name.capitalize()}" }
-                    ?.invoke(this)
-                    .toString()
-            }
+            .filter { !it.type.isLambda() }
+            .map { field -> field.name to getFieldStringValue(field) }
             .toMap()
+    }
+
+    private fun Any.getFieldStringValue(field: Field): String {
+        return javaClass.methods
+            .find { it.name == "get${field.name.capitalize()}" }
+            ?.invoke(this)
+            .toString()
     }
 }

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/transport/TestRuntimeDataBuilder.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/transport/TestRuntimeDataBuilder.kt
@@ -19,7 +19,7 @@ class TestRuntimeDataBuilder(private val timeProvider: TimeProvider) : PreTransp
                 startTime = state.startTime,
                 endTime = state.endTime
             )
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             createSafeRuntimeMetadataWithError("Can't build test runtime data", e)
         }
     }

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/util/ReflectionExt.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/util/ReflectionExt.kt
@@ -14,3 +14,5 @@ internal fun Any.executeMethod(method: String, vararg arguments: Any?) {
             )
         }
 }
+
+internal fun Class<*>.isLambda(): Boolean = Function::class.java.isAssignableFrom(this)

--- a/subprojects/android-test/test-report/src/test/kotlin/com/avito/android/test/report/transport/DataSetSerializerKtTest.kt
+++ b/subprojects/android-test/test-report/src/test/kotlin/com/avito/android/test/report/transport/DataSetSerializerKtTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("IllegalIdentifier")
-
 package com.avito.android.test.report.transport
 
 import com.avito.android.test.report.model.DataSet
@@ -11,7 +9,7 @@ class DataSetSerializerKtTest : PreTransportMappers {
     @Test
     fun `serialize() - produces null - for empty dataSet`() {
         val dataSet: DataSet = object : DataSet {}
-        assertThat(dataSet.serialize()).isEqualTo(emptyMap<Any, Any>())
+        assertThat(dataSet.serialize()).isEqualTo(emptyMap<String, Any>())
     }
 
     @Test
@@ -20,5 +18,12 @@ class DataSetSerializerKtTest : PreTransportMappers {
 
         assertThat(SinglePropertyDataSet("myValue").serialize())
             .isEqualTo(mapOf("myProperty" to "myValue"))
+    }
+
+    @Test
+    fun `serialize() - not serializing lambda`() {
+        class LambdaPropertyDataSet(@Suppress("unused") val myLambda: () -> String) : DataSet
+
+        assertThat(LambdaPropertyDataSet { "Hello" }.serialize()).isEqualTo(emptyMap<String, Any>())
     }
 }


### PR DESCRIPTION
sometimes leads to KotlinReflectionInternalError; see [KT-40666](https://youtrack.jetbrains.com/issue/KT-40666)

promote LOST causes to Critical
catch Throwables not Exceptions