### PR TITLE
Fix UnitTestCheck.kt

### DIFF
--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/UnitTestCheck.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/UnitTestCheck.kt
@@ -17,7 +17,6 @@ open class UnitTestCheck(context: String, name: String) : BuildStep(context, nam
 
             val configurations = project.internalModule.let {
                 listOf(
-                    it.androidTestConfiguration,
                     it.testConfiguration,
                     it.implementationConfiguration
                 )


### PR DESCRIPTION
We don't need to execute unit-test when android-test configuration change