### PR TITLE
Mbs 10577 Warn about not found resources from config in build check

### DIFF
--- a/subprojects/gradle/build-checks/src/gradleTest/kotlin/com/avito/android/build_checks/unique_app_res/UniqueAppResourcesTest.kt
+++ b/subprojects/gradle/build-checks/src/gradleTest/kotlin/com/avito/android/build_checks/unique_app_res/UniqueAppResourcesTest.kt
@@ -213,6 +213,44 @@ internal class UniqueAppResourcesTest {
     }
 
     @Test
+    fun `warn - unknown ignored resource`() {
+        TestProjectGenerator(
+            plugins = plugins {
+                id("com.avito.android.impact")
+            },
+            modules = listOf(
+                AndroidAppModule(
+                    name = "app",
+                    packageName = "com.app",
+                    plugins = plugins {
+                        id("com.avito.android.build-checks")
+                    },
+                    dependencies = setOf(
+                        project(":lib-a")
+                    ),
+                    buildGradleExtra = """
+                        buildChecks {
+                            enableByDefault = false
+                            uniqueAppResources {
+                                enabled = true
+                                ignoredResource("string", "unknown_res_id")
+                            }
+                        }
+                        """.trimIndent()
+                ),
+                AndroidLibModule(name = "lib-a", packageName = "lib_a"),
+            ),
+        ).generateIn(projectDir)
+
+        val build = runCheck()
+
+        build.assertThat()
+            .buildSuccessful()
+            .outputContains("Application :app defines unknown resources in 'uniqueAppResources':")
+            .outputContains("- string 'unknown_res_id'")
+    }
+
+    @Test
     fun `fail - invalid resource type in a config`() {
         TestProjectGenerator(
             plugins = plugins {

--- a/subprojects/gradle/build-checks/src/main/kotlin/com/avito/android/build_checks/internal/FailedCheckMessage.kt
+++ b/subprojects/gradle/build-checks/src/main/kotlin/com/avito/android/build_checks/internal/FailedCheckMessage.kt
@@ -26,6 +26,8 @@ $extensionName {
         enabled = false
     }
 }
-See https://avito-tech.github.io/avito-android/projects/BuildChecks (search '$checkExtensionName')
+See $docsLink (search '$checkExtensionName')
 """.trimIndent()
 }
+
+internal const val docsLink = "https://avito-tech.github.io/avito-android/projects/BuildChecks"

--- a/subprojects/gradle/build-checks/src/main/kotlin/com/avito/android/build_checks/internal/unique_app_res/Resource.kt
+++ b/subprojects/gradle/build-checks/src/main/kotlin/com/avito/android/build_checks/internal/unique_app_res/Resource.kt
@@ -2,7 +2,7 @@ package com.avito.android.build_checks.internal.unique_app_res
 
 import com.android.resources.ResourceType
 
-public data class Resource(
+internal data class Resource(
     val type: ResourceType,
     val name: String
 ) : java.io.Serializable

--- a/subprojects/gradle/build-checks/src/main/kotlin/com/avito/android/build_checks/internal/unique_app_res/Resource.kt
+++ b/subprojects/gradle/build-checks/src/main/kotlin/com/avito/android/build_checks/internal/unique_app_res/Resource.kt
@@ -2,7 +2,7 @@ package com.avito.android.build_checks.internal.unique_app_res
 
 import com.android.resources.ResourceType
 
-internal data class Resource(
+public data class Resource(
     val type: ResourceType,
     val name: String
 ) : java.io.Serializable

--- a/subprojects/gradle/build-checks/src/main/kotlin/com/avito/android/build_checks/internal/unique_app_res/UndeclaredResourcesFinder.kt
+++ b/subprojects/gradle/build-checks/src/main/kotlin/com/avito/android/build_checks/internal/unique_app_res/UndeclaredResourcesFinder.kt
@@ -1,0 +1,33 @@
+package com.avito.android.build_checks.internal.unique_app_res
+
+import com.android.ide.common.symbols.SymbolTable
+import com.android.resources.ResourceType
+
+internal interface UndeclaredResourcesFinder {
+
+    fun findResources(): Set<Resource>
+}
+
+internal class UndeclaredResourcesFinderImpl(
+    private val symbolTables: List<SymbolTable>,
+    private val resources: Set<Resource>
+) : UndeclaredResourcesFinder {
+
+    override fun findResources(): Set<Resource> {
+        val resourceTypes: Set<ResourceType> = resources.mapTo(mutableSetOf()) { it.type }
+        val undeclared: MutableSet<Resource> = resources.toMutableSet()
+
+        symbolTables.forEach { table ->
+            table.resourceTypes
+                .filter { resourceTypes.contains(it) }
+                .forEach { resourceType ->
+                    table.getSymbolByResourceType(resourceType)
+                        .map { it.name }
+                        .forEach { symbolName ->
+                            undeclared.remove(Resource(resourceType, symbolName))
+                        }
+                }
+        }
+        return undeclared
+    }
+}

--- a/subprojects/gradle/build-checks/src/test/kotlin/com/avito/android/build_checks/unique_app_res/UndeclaredResourcesFinderTest.kt
+++ b/subprojects/gradle/build-checks/src/test/kotlin/com/avito/android/build_checks/unique_app_res/UndeclaredResourcesFinderTest.kt
@@ -1,0 +1,86 @@
+package com.avito.android.build_checks.unique_app_res
+
+import com.android.ide.common.symbols.SymbolTable
+import com.android.resources.ResourceType
+import com.avito.android.build_checks.internal.unique_app_res.Resource
+import com.avito.android.build_checks.internal.unique_app_res.UndeclaredResourcesFinderImpl
+import com.avito.android.build_checks.internal.unique_app_res.parsePackageAwareR
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+internal class UndeclaredResourcesFinderTest {
+
+    private lateinit var packageAwareRFile: File
+
+    @BeforeEach
+    fun setup(@TempDir tempDir: Path) {
+        packageAwareRFile = File(tempDir.toFile(), "package-aware-r.txt")
+    }
+
+    @Test
+    fun `empty result - all ignored resources found`() {
+        val symbolsA = readSymbols(
+            """
+            |lib.a
+            |layout details
+            |string auth
+        """.trimMargin()
+        )
+
+        val symbolsB = readSymbols(
+            """
+            |lib.b
+            |layout main
+            |string title
+        """.trimMargin()
+        )
+
+        val duplicates = findResources(
+            listOf(symbolsA, symbolsB),
+            resources = setOf(
+                Resource(ResourceType.STRING, "title"),
+                Resource(ResourceType.LAYOUT, "details"),
+            )
+        )
+
+        assertThat(duplicates).isEmpty()
+    }
+
+    @Test
+    fun `found undeclared - ignored resource is not in apps`() {
+        val symbols = readSymbols(
+            """
+            |lib.a
+            |string title
+            |layout main
+        """.trimMargin()
+        )
+
+        val unknownRes = Resource(ResourceType.STRING, "unknown_res")
+        val duplicates = findResources(
+            listOf(symbols),
+            resources = setOf(unknownRes)
+        )
+
+        assertThat(duplicates).contains(unknownRes)
+    }
+
+    private fun findResources(
+        symbols: List<SymbolTable>,
+        resources: Set<Resource> = emptySet()
+    ): Set<Resource> {
+        return UndeclaredResourcesFinderImpl(
+            symbols,
+            resources
+        ).findResources()
+    }
+
+    private fun readSymbols(content: String): SymbolTable {
+        packageAwareRFile.writeText(content)
+        return parsePackageAwareR(packageAwareRFile.toPath())
+    }
+}


### PR DESCRIPTION
Warn about obsolete resources in a config:

```kotlin
buildChecks {
    uniqueAppResources {
        ignoredResources.put("bool", "is_tablet") <---
    }
}
```

```
Application :app defines unknown resources in 'uniqueAppResources':
- bool 'is_tablet' 
Remove them.
See https://avito-tech.github.io/avito-android/projects/BuildChecks for details.
```
