### PR TITLE
MBS-10556 add missing retries to ReportApi and FileStorage

### DIFF
--- a/build-logic/testing-convention/src/main/kotlin/convention.gradle-testing.gradle.kts
+++ b/build-logic/testing-convention/src/main/kotlin/convention.gradle-testing.gradle.kts
@@ -40,16 +40,6 @@ val gradleTestTask = tasks.register<Test>("gradleTest") {
     systemProperty("compileSdkVersion", libs.compileSdkVersion)
     systemProperty("buildToolsVersion", libs.buildToolsVersion)
     systemProperty("androidGradlePluginVersion", libs.androidGradlePluginVersion)
-
-    /**
-     * IDEA adds an init script, using it to define if it is an IDE run
-     * used in `:test-project`
-     */
-    systemProperty(
-        "isInvokedFromIde",
-        gradle.startParameter.allInitScripts.find { it.name.contains("ijtestinit") } != null
-    )
-
     systemProperty("isTest", true)
 
     systemProperty("junit.jupiter.execution.timeout.default", testTimeoutSeconds)

--- a/build-logic/testing-convention/src/main/kotlin/convention.unit-testing.gradle.kts
+++ b/build-logic/testing-convention/src/main/kotlin/convention.unit-testing.gradle.kts
@@ -19,6 +19,15 @@ tasks.withType<Test>().configureEach {
      * fix for multiple `WARNING: Illegal reflective access`
      */
     jvmArgs = listOf("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+
+    /**
+     * IDEA adds an init script, using it to define if it is an IDE run
+     * used in `:test-project`
+     */
+    systemProperty(
+        "isInvokedFromIde",
+        gradle.startParameter.allInitScripts.find { it.name.contains("ijtestinit") } != null
+    )
 }
 
 plugins.withType<KotlinBasePluginWrapper>() {

--- a/subprojects/common/report-viewer/src/main/kotlin/com/avito/report/ReportsApi.kt
+++ b/subprojects/common/report-viewer/src/main/kotlin/com/avito/report/ReportsApi.kt
@@ -1,5 +1,6 @@
 package com.avito.report
 
+import com.avito.http.RetryInterceptor
 import com.avito.logger.LoggerFactory
 import com.avito.logger.create
 import com.avito.report.internal.JsonRpcRequestProvider
@@ -66,15 +67,21 @@ interface ReportsApi : ReportsAddApi, ReportsFetchApi {
             verboseHttp: Boolean = false
         ): ReportsApi {
 
+            val logger = loggerFactory.create<ReportsApi>()
+
             return ReportsApiImpl(
                 loggerFactory = loggerFactory,
                 requestProvider = JsonRpcRequestProvider(
                     host = host,
                     httpClient = getHttpClient(
                         verbose = verboseHttp,
-                        logger = loggerFactory.create<ReportsApi>(),
+                        logger = logger,
                         readTimeoutSec = readTimeout,
-                        writeTimeoutSec = writeTimeout
+                        writeTimeoutSec = writeTimeout,
+                        retryInterceptor = RetryInterceptor(
+                            logger = logger,
+                            allowedMethods = listOf("POST")
+                        )
                     ),
                     gson = gson
                 )

--- a/subprojects/common/report-viewer/src/main/kotlin/com/avito/report/internal/HttpClientProvider.kt
+++ b/subprojects/common/report-viewer/src/main/kotlin/com/avito/report/internal/HttpClientProvider.kt
@@ -12,16 +12,19 @@ fun getHttpClient(
     verbose: Boolean = false,
     logger: Logger,
     readTimeoutSec: Long,
-    writeTimeoutSec: Long
+    writeTimeoutSec: Long,
+    retryInterceptor: RetryInterceptor?
 ): OkHttpClient {
 
     return OkHttpClient.Builder()
         .readTimeout(readTimeoutSec, TimeUnit.SECONDS)
         .writeTimeout(writeTimeoutSec, TimeUnit.SECONDS)
-        .addInterceptor(RetryInterceptor(logger = logger))
         .apply {
             if (verbose) {
                 addInterceptor(HttpLoggingInterceptor(HttpLogger(logger)).setLevel(Level.BODY))
+            }
+            if (retryInterceptor != null) {
+                addInterceptor(retryInterceptor)
             }
         }
         .build()

--- a/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/report/listener/ReportViewerTestReporter.kt
+++ b/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/report/listener/ReportViewerTestReporter.kt
@@ -3,6 +3,7 @@ package com.avito.instrumentation.internal.report.listener
 import com.avito.android.runner.report.Report
 import com.avito.filestorage.HttpRemoteStorage
 import com.avito.filestorage.RemoteStorage
+import com.avito.http.RetryInterceptor
 import com.avito.instrumentation.metrics.InstrumentationMetricsSender
 import com.avito.logger.LoggerFactory
 import com.avito.logger.create
@@ -47,7 +48,11 @@ internal class ReportViewerTestReporter(
         verbose = false, // do not enable for production, generates a ton of logs
         logger = logger,
         readTimeoutSec = httpTimeoutSec,
-        writeTimeoutSec = httpTimeoutSec
+        writeTimeoutSec = httpTimeoutSec,
+        retryInterceptor = RetryInterceptor(
+            logger = logger,
+            allowedMethods = listOf("POST")
+        )
     )
 
     /**


### PR DESCRIPTION
All methods are POST, was retrying only GET's
discovered while browsing kibana logs