### PR TITLE
MBS-10571 use Time instead of Count for Adb metrics

### DIFF
--- a/docs/content/test_runner/Metrics.md
+++ b/docs/content/test_runner/Metrics.md
@@ -4,7 +4,7 @@
 
 Metrics available at:
 
-`$namespace.testrunner.$buildId.$projectName.$instrumentationConfigName.`
+`$namespace.testrunner.$projectName.$instrumentationConfigName.`
 
 ### `device-utilization.median`
 

--- a/docs/content/test_runner/Metrics.md
+++ b/docs/content/test_runner/Metrics.md
@@ -4,7 +4,7 @@
 
 Metrics available at:
 
-`$namespace.testrunner.$buildId.$instrumentationConfigName.`
+`$namespace.testrunner.$buildId.$projectName.$instrumentationConfigName.`
 
 ### `device-utilization.median`
 

--- a/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/InstrumentationTestsActionFactory.kt
+++ b/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/InstrumentationTestsActionFactory.kt
@@ -28,6 +28,7 @@ internal interface InstrumentationTestsActionFactory {
             runnerPrefix = SeriesName.create(
                 "testrunner",
                 params.buildId,
+                params.projectName,
                 params.instrumentationConfiguration.name
             )
         )

--- a/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/InstrumentationTestsActionFactory.kt
+++ b/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/InstrumentationTestsActionFactory.kt
@@ -27,7 +27,6 @@ internal interface InstrumentationTestsActionFactory {
             gson = Companion.gson,
             runnerPrefix = SeriesName.create(
                 "testrunner",
-                params.buildId,
                 params.projectName,
                 params.instrumentationConfiguration.name
             )

--- a/subprojects/gradle/runner/client/src/test/kotlin/com/avito/runner/scheduler/runner/RunnerIntegrationTest.kt
+++ b/subprojects/gradle/runner/client/src/test/kotlin/com/avito/runner/scheduler/runner/RunnerIntegrationTest.kt
@@ -586,7 +586,7 @@ class RunnerIntegrationTest {
         )
     }
 
-    private fun succeedClearPackage() = StubActionResult.Success<Try<Any>>(Try.Success(Unit))
+    private fun succeedClearPackage() = StubActionResult.Success<Try<Unit>>(Try.Success(Unit))
 
     private fun provideRunner(
         devices: ReceiveChannel<Device>,

--- a/subprojects/gradle/runner/device-provider/src/main/kotlin/com/avito/android/runner/devices/internal/StubDevicesProvider.kt
+++ b/subprojects/gradle/runner/device-provider/src/main/kotlin/com/avito/android/runner/devices/internal/StubDevicesProvider.kt
@@ -90,7 +90,7 @@ internal class StubDevicesProvider(
         )
     }
 
-    private fun succeedClearPackage(): StubActionResult.Success<Try<Any>> {
+    private fun succeedClearPackage(): StubActionResult.Success<Try<Unit>> {
         return StubActionResult.Success(
             Try.Success(Unit)
         )

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/DeviceStateWorker.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/DeviceStateWorker.kt
@@ -25,7 +25,7 @@ internal class DeviceStateWorker(private val device: Device) {
             resultAggregator = {}
         )
 
-    fun clearPackages(state: State): Try<Any> = state.layers
+    fun clearPackages(state: State): Try<Unit> = state.layers
         .asSequence()
         .filterIsInstance<InstalledApplication>()
         .map {

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/Device.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/Device.kt
@@ -31,11 +31,11 @@ interface Device {
         outputDir: File
     ): DeviceTestCaseRun
 
-    fun clearPackage(name: String): Try<Any>
+    fun clearPackage(name: String): Try<Unit>
 
-    fun pull(from: Path, to: Path): Try<Any>
+    fun pull(from: Path, to: Path): Try<Unit>
 
-    fun clearDirectory(remotePath: Path): Try<Any>
+    fun clearDirectory(remotePath: Path): Try<Unit>
 
     fun list(remotePath: String): Try<List<String>>
 

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
@@ -55,8 +55,8 @@ data class AdbDevice(
 
     override val api: Int by lazy {
         retryAction.retry(
-            retriesCount = 5,
-            delaySeconds = 3,
+            retriesCount = DEFAULT_RETRY_COUNT,
+            delaySeconds = DEFAULT_DELAY_SEC,
             action = {
                 loadProperty(
                     key = "ro.build.version.sdk",
@@ -308,8 +308,8 @@ data class AdbDevice(
     ).toTry()
 
     override fun pull(from: Path, to: Path): Try<Unit> = retryAction.retry(
-        retriesCount = 5,
-        delaySeconds = 3,
+        retriesCount = DEFAULT_RETRY_COUNT,
+        delaySeconds = DEFAULT_DELAY_SEC,
         action = {
             executeBlockingCommand(
                 command = listOf(
@@ -359,8 +359,8 @@ data class AdbDevice(
     ).toTry()
 
     override fun clearDirectory(remotePath: Path): Try<Unit> = retryAction.retry(
-        retriesCount = 5,
-        delaySeconds = 3,
+        retriesCount = DEFAULT_RETRY_COUNT,
+        delaySeconds = DEFAULT_DELAY_SEC,
         action = {
             executeBlockingShellCommand(
                 command = listOf(
@@ -398,8 +398,8 @@ data class AdbDevice(
     ).map { }.toTry()
 
     override fun list(remotePath: String): Try<List<String>> = retryAction.retry(
-        retriesCount = 5,
-        delaySeconds = 3,
+        retriesCount = DEFAULT_RETRY_COUNT,
+        delaySeconds = DEFAULT_DELAY_SEC,
         action = {
             executeBlockingShellCommand(
                 command = listOf(
@@ -587,6 +587,8 @@ data class AdbDevice(
 private const val DEFAULT_COMMAND_TIMEOUT_SECONDS = 5L
 private const val DDMLIB_SOCKET_TIME_OUT_SECONDS = 20L
 private const val WAIT_FOR_ADB_TIME_OUT_MINUTES = 1L
+private const val DEFAULT_RETRY_COUNT = 5
+private const val DEFAULT_DELAY_SEC = 3L
 
 private fun createEventListener(
     loggerFactory: LoggerFactory,

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
@@ -8,7 +8,6 @@ import com.avito.logger.Logger
 import com.avito.logger.LoggerFactory
 import com.avito.runner.CommandLineExecutor
 import com.avito.runner.ProcessNotification
-import com.avito.runner.retry
 import com.avito.runner.service.model.DeviceTestCaseRun
 import com.avito.runner.service.model.TestCase
 import com.avito.runner.service.model.TestCaseRun
@@ -50,59 +49,81 @@ data class AdbDevice(
         runnerMetricsConfig = metricsConfig
     ),
     private val commandLine: CommandLineExecutor = CommandLineExecutor.Impl(),
-    private val instrumentationParser: InstrumentationTestCaseRunParser = InstrumentationTestCaseRunParser.Impl()
+    private val instrumentationParser: InstrumentationTestCaseRunParser = InstrumentationTestCaseRunParser.Impl(),
+    private val retryAction: RetryAction = RetryAction(timeProvider)
 ) : Device {
 
     override val api: Int by lazy {
-        retry(
+        retryAction.retry(
             retriesCount = 5,
             delaySeconds = 3,
-            block = { attempt ->
-                val result = loadProperty(
+            action = {
+                loadProperty(
                     key = "ro.build.version.sdk",
                     cast = { it.toInt() }
                 )
-                eventsListener.onGetSdkPropertySuccess(attempt, result)
-                result
             },
-            attemptFailedHandler = { attempt, _ ->
-                eventsListener.onGetSdkPropertyError(attempt)
+            onError = { attempt, _, durationMs ->
+                eventsListener.onGetSdkPropertyError(attempt, durationMs)
             },
-            actionFailedHandler = { throwable ->
-                eventsListener.onGetSdkPropertyFailure(throwable)
+            onFailure = { throwable, durationMs ->
+                eventsListener.onGetSdkPropertyFailure(throwable, durationMs)
+            },
+            onSuccess = { attempt, result, durationMs ->
+                eventsListener.onGetSdkPropertySuccess(attempt, result, durationMs)
             }
-        )
+        ).getOrThrow()
     }
 
     override fun installApplication(applicationPackage: String): Try<DeviceInstallation> {
-        var installStartedTimestamp = 0L
+        var installStartedTimestamp: Long
         return getAdbDevice().flatMap { adbDevice ->
 
             installStartedTimestamp = timeProvider.nowInMillis()
 
-            runWithRetries(
+            retryAction.retry(
                 retriesCount = 10,
                 delaySeconds = 5,
-                block = { attempt ->
+                action = {
                     adbDevice.installPackage(applicationPackage, true)
-                    eventsListener.onInstallApplicationSuccess(this, attempt, applicationPackage)
                 },
-                attemptFailedHandler = { attempt, _ ->
-                    eventsListener.onInstallApplicationError(this, attempt, applicationPackage)
+                onError = { attempt: Int, throwable: Throwable, durationMs: Long ->
+                    eventsListener.onInstallApplicationError(
+                        device = this,
+                        attempt = attempt,
+                        applicationPackage = applicationPackage,
+                        throwable = throwable,
+                        durationMs = durationMs
+                    )
                 },
-                onError = { throwable ->
-                    eventsListener.onInstallApplicationFailure(this, applicationPackage, throwable)
+                onFailure = { throwable: Throwable, durationMs: Long ->
+                    eventsListener.onInstallApplicationFailure(
+                        device = this,
+                        applicationPackage = applicationPackage,
+                        throwable = throwable,
+                        durationMs = durationMs
+                    )
+                },
+                onSuccess = { attempt: Int, _: Unit, durationMs: Long ->
+                    eventsListener.onInstallApplicationSuccess(
+                        device = this,
+                        attempt = attempt,
+                        applicationPackage = applicationPackage,
+                        durationMs = durationMs
+                    )
                 }
             )
-        }.map {
-            DeviceInstallation(
-                installation = Installation(
-                    application = applicationPackage,
-                    timestampStartedMilliseconds = installStartedTimestamp,
-                    timestampCompletedMilliseconds = timeProvider.nowInMillis()
-                ),
-                device = this.getData()
-            )
+                .map {
+                    DeviceInstallation(
+                        installation = Installation(
+                            application = applicationPackage,
+                            timestampStartedMilliseconds = installStartedTimestamp,
+                            timestampCompletedMilliseconds = timeProvider.nowInMillis()
+                        ),
+                        device = this.getData()
+                    )
+                }
+                .toTry()
         }
     }
 
@@ -114,6 +135,8 @@ data class AdbDevice(
         val finalInstrumentationArguments = action.instrumentationParams.plus(
             "class" to "${action.test.className}#${action.test.methodName}"
         )
+
+        val startTime = timeProvider.nowInMillis()
 
         return runTest(
             test = action.test,
@@ -129,20 +152,30 @@ data class AdbDevice(
                     is InstrumentationTestCaseRun.CompletedTestCaseRun -> {
                         val testName = "${it.className}.${it.name}"
                         when (it.result) {
-                            TestCaseRun.Result.Passed -> eventsListener.onRunTestPassed(this, testName)
-                            TestCaseRun.Result.Ignored -> eventsListener.onRunTestIgnored(this, testName)
+                            TestCaseRun.Result.Passed -> eventsListener.onRunTestPassed(
+                                device = this,
+                                testName = testName,
+                                durationMs = timeProvider.nowInMillis() - startTime
+                            )
+                            TestCaseRun.Result.Ignored -> eventsListener.onRunTestIgnored(
+                                device = this,
+                                testName = testName,
+                                durationMs = timeProvider.nowInMillis() - startTime
+                            )
                             is TestCaseRun.Result.Failed.InRun ->
                                 eventsListener.onRunTestRunError(
                                     device = this,
                                     testName = testName,
-                                    errorMessage = it.result.errorMessage
+                                    errorMessage = it.result.errorMessage,
+                                    durationMs = timeProvider.nowInMillis() - startTime
                                 )
                             is TestCaseRun.Result.Failed.InfrastructureError ->
                                 eventsListener.onRunTestInfrastructureError(
                                     device = this,
                                     testName = testName,
                                     errorMessage = it.result.errorMessage,
-                                    throwable = it.result.cause
+                                    throwable = it.result.cause,
+                                    durationMs = timeProvider.nowInMillis() - startTime
                                 )
                         }
                         DeviceTestCaseRun(
@@ -160,7 +193,11 @@ data class AdbDevice(
                         )
                     }
                     is InstrumentationTestCaseRun.FailedOnStartTestCaseRun -> {
-                        eventsListener.onRunTestFailedOnStart(this, it.message)
+                        eventsListener.onRunTestFailedOnStart(
+                            device = this,
+                            message = it.message,
+                            durationMs = timeProvider.nowInMillis() - startTime
+                        )
                         DeviceTestCaseRun(
                             testCaseRun = TestCaseRun(
                                 test = action.test,
@@ -174,7 +211,12 @@ data class AdbDevice(
                         )
                     }
                     is InstrumentationTestCaseRun.FailedOnInstrumentationParsing -> {
-                        eventsListener.onRunTestFailedOnInstrumentationParse(this, it.message, it.throwable)
+                        eventsListener.onRunTestFailedOnInstrumentationParse(
+                            device = this,
+                            message = it.message,
+                            throwable = it.throwable,
+                            durationMs = timeProvider.nowInMillis()
+                        )
                         DeviceTestCaseRun(
                             testCaseRun = TestCaseRun(
                                 test = action.test,
@@ -194,145 +236,203 @@ data class AdbDevice(
             .value()
     }
 
-    override fun deviceStatus(): Device.DeviceStatus = try {
-        retry(
-            retriesCount = 15,
-            delaySeconds = 5,
-            block = { attempt ->
-                val bootCompleted: Boolean = loadProperty(
-                    key = "sys.boot_completed",
-                    cast = { output -> output == "1" }
-                )
+    override fun deviceStatus(): Device.DeviceStatus = retryAction.retry(
+        retriesCount = 15,
+        delaySeconds = 5,
+        action = {
+            val bootCompleted: Boolean = loadProperty(
+                key = "sys.boot_completed",
+                cast = { output -> output == "1" }
+            )
 
-                if (!bootCompleted) {
-                    throw IllegalStateException("sys.boot_completed isn't '1'")
-                }
-
-                eventsListener.onGetAliveDeviceSuccess(this, attempt)
-
-                Device.DeviceStatus.Alive
-            },
-            attemptFailedHandler = { attempt, _ ->
-                eventsListener.onGetAliveDeviceError(this, attempt)
-            },
-            actionFailedHandler = { throwable ->
-                eventsListener.onGetAliveDeviceFailed(this, throwable)
+            if (!bootCompleted) {
+                throw IllegalStateException("sys.boot_completed isn't '1'")
             }
+
+            bootCompleted
+        },
+        onError = { attempt: Int, _: Throwable, durationMs: Long ->
+            eventsListener.onGetAliveDeviceError(this, attempt, durationMs)
+        },
+        onFailure = { throwable, durationMs ->
+            eventsListener.onGetAliveDeviceFailed(this, throwable, durationMs)
+        },
+        onSuccess = { attempt: Int, _: Boolean, durationMs: Long ->
+            eventsListener.onGetAliveDeviceSuccess(this, attempt, durationMs)
+        }
+    )
+        .fold(
+            { Device.DeviceStatus.Alive },
+            { throwable: Throwable -> Device.DeviceStatus.Freeze(reason = throwable) }
         )
-    } catch (t: Throwable) {
-        Device.DeviceStatus.Freeze(reason = t)
-    }
 
-    override fun clearPackage(name: String): Try<Any> = Try {
-        runWithRetries(
-            retriesCount = 10,
-            delaySeconds = 2,
-            block = { attempt ->
-                val result = executeBlockingShellCommand(
-                    command = listOf("pm", "clear", name),
-                    // was seeing ~20% error rate at 5s
-                    timeoutSeconds = 10
-                )
+    override fun clearPackage(name: String): Try<Unit> = retryAction.retry(
+        retriesCount = 10,
+        delaySeconds = 2,
+        action = {
+            val result = executeBlockingShellCommand(
+                command = listOf("pm", "clear", name),
+                // was seeing ~20% error rate at 5s
+                timeoutSeconds = 10
+            )
 
-                if (!result.output.contains("success", ignoreCase = true)) {
-                    throw IllegalStateException("Fail to clear package $name; output=${result.output}")
-                }
-
-                eventsListener.onClearPackageSuccess(this, attempt, name)
-            },
-            attemptFailedHandler = { attempt, throwable ->
-                eventsListener.onClearPackageError(this, attempt, name, throwable)
-            },
-            onError = { throwable ->
-                eventsListener.onClearPackageFailure(this, name, throwable)
+            if (!result.output.contains("success", ignoreCase = true)) {
+                throw IllegalStateException("Fail to clear package $name; output=${result.output}")
             }
-        )
-    }
+        },
+        onError = { attempt: Int, throwable: Throwable, durationMs: Long ->
+            eventsListener.onClearPackageError(
+                device = this,
+                attempt = attempt,
+                name = name,
+                throwable = throwable,
+                durationMs = durationMs
+            )
+        },
+        onFailure = { throwable: Throwable, durationMs: Long ->
+            eventsListener.onClearPackageFailure(
+                device = this,
+                name = name,
+                throwable = throwable,
+                durationMs = durationMs
+            )
+        },
+        onSuccess = { attempt: Int, _: Any, durationMs: Long ->
+            eventsListener.onClearPackageSuccess(
+                device = this,
+                attempt = attempt,
+                name = name,
+                durationMs = durationMs
+            )
+        }
+    ).toTry()
 
-    override fun pull(from: Path, to: Path): Try<Any> = Try {
-        retry(
-            retriesCount = 5,
-            delaySeconds = 3,
-            block = {
-                executeBlockingCommand(
-                    command = listOf(
-                        "pull",
-                        from.toString(),
-                        to.toString()
-                    )
+    override fun pull(from: Path, to: Path): Try<Unit> = retryAction.retry(
+        retriesCount = 5,
+        delaySeconds = 3,
+        action = {
+            executeBlockingCommand(
+                command = listOf(
+                    "pull",
+                    from.toString(),
+                    to.toString()
                 )
+            )
 
-                val resultFile = File(
-                    to.toFile(),
-                    from.fileName.toString()
+            val resultFile = File(
+                to.toFile(),
+                from.fileName.toString()
+            )
+
+            if (!resultFile.exists()) {
+                throw RuntimeException(
+                    "Failed to pull file from ${from.toAbsolutePath()} to ${to.toAbsolutePath()}. " +
+                        "Result file: ${resultFile.absolutePath} not found."
                 )
-
-                if (!resultFile.exists()) {
-                    throw RuntimeException(
-                        "Failed to pull file from ${from.toAbsolutePath()} to ${to.toAbsolutePath()}. " +
-                            "Result file: ${resultFile.absolutePath} not found."
-                    )
-                }
-
-                eventsListener.onPullSuccess(this, from, to)
-            },
-            attemptFailedHandler = { attempt, throwable ->
-                eventsListener.onPullError(this, attempt, from, throwable)
-            },
-            actionFailedHandler = { throwable ->
-                eventsListener.onPullFailure(this, from, throwable)
             }
-        )
-    }
+        },
+        onError = { attempt: Int, throwable: Throwable, durationMs: Long ->
+            eventsListener.onPullError(
+                device = this,
+                attempt = attempt,
+                from = from,
+                throwable = throwable,
+                durationMs = durationMs
+            )
+        },
+        onFailure = { throwable: Throwable, durationMs: Long ->
+            eventsListener.onPullFailure(
+                device = this,
+                from = from,
+                throwable = throwable,
+                durationMs = durationMs
+            )
+        },
+        onSuccess = { _: Int, _: Any, durationMs: Long ->
+            eventsListener.onPullSuccess(
+                device = this,
+                from = from,
+                to = to,
+                durationMs = durationMs
+            )
+        }
+    ).toTry()
 
-    override fun clearDirectory(remotePath: Path): Try<Any> = Try {
-        retry(
-            retriesCount = 5,
-            delaySeconds = 3,
-            block = {
-                val result = executeBlockingShellCommand(
-                    command = listOf(
-                        "rm",
-                        "-rf",
-                        remotePath.toString()
-                    )
+    override fun clearDirectory(remotePath: Path): Try<Unit> = retryAction.retry(
+        retriesCount = 5,
+        delaySeconds = 3,
+        action = {
+            executeBlockingShellCommand(
+                command = listOf(
+                    "rm",
+                    "-rf",
+                    remotePath.toString()
                 )
+            )
+        },
+        onError = { attempt: Int, throwable: Throwable, durationMs: Long ->
+            eventsListener.onClearDirectoryError(
+                device = this,
+                attempt = attempt,
+                remotePath = remotePath,
+                throwable = throwable,
+                durationMs = durationMs
+            )
+        },
+        onFailure = { throwable: Throwable, durationMs: Long ->
+            eventsListener.onClearDirectoryFailure(
+                device = this,
+                remotePath = remotePath,
+                throwable = throwable,
+                durationMs = durationMs
+            )
+        },
+        onSuccess = { _: Int, result: ProcessNotification.Exit, durationMs: Long ->
+            eventsListener.onClearDirectorySuccess(
+                device = this,
+                remotePath = remotePath,
+                output = result.output,
+                durationMs = durationMs
+            )
+        }
+    ).map { }.toTry()
 
-                eventsListener.onClearDirectorySuccess(this, remotePath, result.output)
-            },
-            attemptFailedHandler = { attempt, throwable ->
-                eventsListener.onClearDirectoryError(this, attempt, remotePath, throwable)
-            },
-            actionFailedHandler = { throwable ->
-                eventsListener.onClearDirectoryFailure(this, remotePath, throwable)
-            }
-        )
-    }
-
-    override fun list(remotePath: String): Try<List<String>> = Try {
-        retry(
-            retriesCount = 5,
-            delaySeconds = 3,
-            block = {
-                val result = executeBlockingShellCommand(
-                    command = listOf(
-                        "ls",
-                        remotePath
-                    )
-                ).output.lines()
-
-                eventsListener.onListSuccess(this, remotePath)
-
-                result
-            },
-            attemptFailedHandler = { attempt, throwable ->
-                eventsListener.onListError(this, attempt, remotePath, throwable)
-            },
-            actionFailedHandler = { throwable ->
-                eventsListener.onListFailure(this, remotePath, throwable)
-            }
-        )
-    }
+    override fun list(remotePath: String): Try<List<String>> = retryAction.retry(
+        retriesCount = 5,
+        delaySeconds = 3,
+        action = {
+            executeBlockingShellCommand(
+                command = listOf(
+                    "ls",
+                    remotePath
+                )
+            ).output.lines()
+        },
+        onError = { attempt: Int, throwable: Throwable, durationMs: Long ->
+            eventsListener.onListError(
+                device = this,
+                attempt = attempt,
+                remotePath = remotePath,
+                throwable = throwable,
+                durationMs = durationMs
+            )
+        },
+        onFailure = { throwable: Throwable, durationMs: Long ->
+            eventsListener.onListFailure(
+                device = this,
+                remotePath = remotePath,
+                throwable = throwable,
+                durationMs = durationMs
+            )
+        },
+        onSuccess = { _: Int, _: List<String>, durationMs: Long ->
+            eventsListener.onListSuccess(
+                device = this,
+                remotePath = remotePath,
+                durationMs = durationMs
+            )
+        }
+    ).toTry()
 
     private fun runTest(
         test: TestCase,
@@ -480,29 +580,6 @@ data class AdbDevice(
             args = listOf("-s", coordinate.serial.value) + command,
             output = redirectOutputTo
         )
-
-    private fun <T> runWithRetries(
-        retriesCount: Int,
-        delaySeconds: Long = 1,
-        attemptFailedHandler: (attempt: Int, throwable: Throwable) -> Unit = { _, _ -> },
-        onError: (throwable: Throwable) -> Unit = {},
-        block: (attempt: Int) -> T
-    ): Try<T> {
-        for (attempt in 0..retriesCount) {
-            if (attempt > 0) TimeUnit.SECONDS.sleep(delaySeconds)
-            try {
-                return Try.Success(block(attempt))
-            } catch (e: Throwable) {
-                if (attempt == retriesCount - 1) {
-                    onError(e)
-                    return Try.Failure(e)
-                } else {
-                    attemptFailedHandler(attempt, e)
-                }
-            }
-        }
-        throw IllegalStateException("retry must return value or throw exception")
-    }
 
     override fun toString(): String = "Device ${coordinate.serial}"
 }

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/Result.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/Result.kt
@@ -1,0 +1,46 @@
+package com.avito.runner.service.worker.device.adb
+
+import org.funktionale.tries.Try
+
+sealed class Result<T> {
+
+    fun getOrThrow(): T = when (this) {
+        is Success -> value
+        is Failure -> throw throwable
+    }
+
+    fun <R> map(transform: (value: T) -> R): Result<R> = when (this) {
+        is Success -> try {
+            Success(transform(value))
+        } catch (throwable: Throwable) {
+            Failure(throwable)
+        }
+        is Failure -> Failure(throwable)
+    }
+
+    fun <R> fold(successTransform: (value: T) -> R, failureTransform: (throwable: Throwable) -> R): R = when (this) {
+        is Success -> successTransform(value)
+        is Failure -> failureTransform(throwable)
+    }
+
+    fun recover(transform: (Throwable) -> T): Result<T> = when (this) {
+        is Success -> this
+        is Failure -> try {
+            Success(transform(throwable))
+        } catch (t: Throwable) {
+            Failure(t)
+        }
+    }
+
+    data class Success<T>(val value: T) : Result<T>()
+
+    data class Failure<T>(val throwable: Throwable) : Result<T>()
+}
+
+/**
+ * todo remove with funktionale
+ */
+fun <T> Result<T>.toTry(): Try<T> = when (this) {
+    is Result.Success -> Try.Success(value)
+    is Result.Failure -> Try.Failure(throwable)
+}

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/RetryAction.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/RetryAction.kt
@@ -1,0 +1,34 @@
+package com.avito.runner.service.worker.device.adb
+
+import com.avito.time.TimeProvider
+import java.util.concurrent.TimeUnit
+
+class RetryAction(private val timeProvider: TimeProvider) {
+
+    fun <T> retry(
+        retriesCount: Int,
+        delaySeconds: Long = 1,
+        onError: (attempt: Int, throwable: Throwable, durationMs: Long) -> Unit = { _, _, _ -> },
+        onFailure: (throwable: Throwable, durationMs: Long) -> Unit = { _, _ -> },
+        onSuccess: (attempt: Int, t: T, durationMs: Long) -> Unit = { _, _, _ -> },
+        action: () -> T
+    ): Result<T> {
+        for (attempt in 0..retriesCount) {
+            val attemptStartTime = timeProvider.nowInMillis()
+            if (attempt > 0) TimeUnit.SECONDS.sleep(delaySeconds)
+            try {
+                val result = action()
+                onSuccess(attempt, result, timeProvider.nowInMillis() - attemptStartTime)
+                return Result.Success(result)
+            } catch (e: Throwable) {
+                if (attempt == retriesCount - 1) {
+                    onFailure(e, timeProvider.nowInMillis() - attemptStartTime)
+                    return Result.Failure(e)
+                } else {
+                    onError(attempt, e, timeProvider.nowInMillis() - attemptStartTime)
+                }
+            }
+        }
+        throw IllegalStateException("retry must return value or throw exception")
+    }
+}

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceEventsListener.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceEventsListener.kt
@@ -5,11 +5,29 @@ import java.nio.file.Path
 
 interface AdbDeviceEventsListener {
 
-    fun onGetSdkPropertySuccess(attempt: Int, api: Int, durationMs: Long)
-    fun onGetSdkPropertyError(attempt: Int, durationMs: Long)
-    fun onGetSdkPropertyFailure(throwable: Throwable, durationMs: Long)
+    fun onGetSdkPropertySuccess(
+        attempt: Int,
+        api: Int,
+        durationMs: Long
+    )
 
-    fun onInstallApplicationSuccess(device: Device, attempt: Int, applicationPackage: String, durationMs: Long)
+    fun onGetSdkPropertyError(
+        attempt: Int,
+        durationMs: Long
+    )
+
+    fun onGetSdkPropertyFailure(
+        throwable: Throwable,
+        durationMs: Long
+    )
+
+    fun onInstallApplicationSuccess(
+        device: Device,
+        attempt: Int,
+        applicationPackage: String,
+        durationMs: Long
+    )
+
     fun onInstallApplicationError(
         device: Device,
         attempt: Int,
@@ -18,31 +36,137 @@ interface AdbDeviceEventsListener {
         durationMs: Long
     )
 
-    fun onInstallApplicationFailure(device: Device, applicationPackage: String, throwable: Throwable, durationMs: Long)
+    fun onInstallApplicationFailure(
+        device: Device,
+        applicationPackage: String,
+        throwable: Throwable,
+        durationMs: Long
+    )
 
-    fun onGetAliveDeviceSuccess(device: Device, attempt: Int, durationMs: Long)
-    fun onGetAliveDeviceError(device: Device, attempt: Int, durationMs: Long)
-    fun onGetAliveDeviceFailed(device: Device, throwable: Throwable, durationMs: Long)
+    fun onGetAliveDeviceSuccess(
+        device: Device,
+        attempt: Int,
+        durationMs: Long
+    )
 
-    fun onClearPackageSuccess(device: Device, attempt: Int, name: String, durationMs: Long)
-    fun onClearPackageError(device: Device, attempt: Int, name: String, throwable: Throwable, durationMs: Long)
-    fun onClearPackageFailure(device: Device, name: String, throwable: Throwable, durationMs: Long)
+    fun onGetAliveDeviceError(
+        device: Device,
+        attempt: Int,
+        durationMs: Long
+    )
 
-    fun onPullSuccess(device: Device, from: Path, to: Path, durationMs: Long)
-    fun onPullError(device: Device, attempt: Int, from: Path, throwable: Throwable, durationMs: Long)
-    fun onPullFailure(device: Device, from: Path, throwable: Throwable, durationMs: Long)
+    fun onGetAliveDeviceFailed(
+        device: Device,
+        throwable: Throwable,
+        durationMs: Long
+    )
 
-    fun onClearDirectorySuccess(device: Device, remotePath: Path, output: String, durationMs: Long)
-    fun onClearDirectoryError(device: Device, attempt: Int, remotePath: Path, throwable: Throwable, durationMs: Long)
-    fun onClearDirectoryFailure(device: Device, remotePath: Path, throwable: Throwable, durationMs: Long)
+    fun onClearPackageSuccess(
+        device: Device,
+        attempt: Int,
+        name: String,
+        durationMs: Long
+    )
 
-    fun onListSuccess(device: Device, remotePath: String, durationMs: Long)
-    fun onListError(device: Device, attempt: Int, remotePath: String, throwable: Throwable, durationMs: Long)
-    fun onListFailure(device: Device, remotePath: String, throwable: Throwable, durationMs: Long)
+    fun onClearPackageError(
+        device: Device,
+        attempt: Int,
+        name: String,
+        throwable: Throwable,
+        durationMs: Long
+    )
 
-    fun onRunTestPassed(device: Device, testName: String, durationMs: Long)
-    fun onRunTestIgnored(device: Device, testName: String, durationMs: Long)
-    fun onRunTestRunError(device: Device, testName: String, errorMessage: String, durationMs: Long)
+    fun onClearPackageFailure(
+        device: Device,
+        name: String,
+        throwable: Throwable,
+        durationMs: Long
+    )
+
+    fun onPullSuccess(
+        device: Device,
+        from: Path,
+        to: Path,
+        durationMs: Long
+    )
+
+    fun onPullError(
+        device: Device,
+        attempt: Int,
+        from: Path,
+        throwable: Throwable,
+        durationMs: Long
+    )
+
+    fun onPullFailure(
+        device: Device,
+        from: Path,
+        throwable: Throwable,
+        durationMs: Long
+    )
+
+    fun onClearDirectorySuccess(
+        device: Device,
+        remotePath: Path,
+        output: String,
+        durationMs: Long
+    )
+
+    fun onClearDirectoryError(
+        device: Device,
+        attempt: Int,
+        remotePath: Path,
+        throwable: Throwable,
+        durationMs: Long
+    )
+
+    fun onClearDirectoryFailure(
+        device: Device,
+        remotePath: Path,
+        throwable: Throwable,
+        durationMs: Long
+    )
+
+    fun onListSuccess(
+        device: Device,
+        remotePath: String,
+        durationMs: Long
+    )
+
+    fun onListError(
+        device: Device,
+        attempt: Int,
+        remotePath: String,
+        throwable: Throwable,
+        durationMs: Long
+    )
+
+    fun onListFailure(
+        device: Device,
+        remotePath: String,
+        throwable: Throwable,
+        durationMs: Long
+    )
+
+    fun onRunTestPassed(
+        device: Device,
+        testName: String,
+        durationMs: Long
+    )
+
+    fun onRunTestIgnored(
+        device: Device,
+        testName: String,
+        durationMs: Long
+    )
+
+    fun onRunTestRunError(
+        device: Device,
+        testName: String,
+        errorMessage: String,
+        durationMs: Long
+    )
+
     fun onRunTestInfrastructureError(
         device: Device,
         testName: String,
@@ -51,6 +175,16 @@ interface AdbDeviceEventsListener {
         durationMs: Long
     )
 
-    fun onRunTestFailedOnStart(device: Device, message: String, durationMs: Long)
-    fun onRunTestFailedOnInstrumentationParse(device: Device, message: String, throwable: Throwable, durationMs: Long)
+    fun onRunTestFailedOnStart(
+        device: Device,
+        message: String,
+        durationMs: Long
+    )
+
+    fun onRunTestFailedOnInstrumentationParse(
+        device: Device,
+        message: String,
+        throwable: Throwable,
+        durationMs: Long
+    )
 }

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceEventsListener.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceEventsListener.kt
@@ -5,38 +5,52 @@ import java.nio.file.Path
 
 interface AdbDeviceEventsListener {
 
-    fun onGetSdkPropertySuccess(attempt: Int, api: Int)
-    fun onGetSdkPropertyError(attempt: Int)
-    fun onGetSdkPropertyFailure(throwable: Throwable)
+    fun onGetSdkPropertySuccess(attempt: Int, api: Int, durationMs: Long)
+    fun onGetSdkPropertyError(attempt: Int, durationMs: Long)
+    fun onGetSdkPropertyFailure(throwable: Throwable, durationMs: Long)
 
-    fun onInstallApplicationSuccess(device: Device, attempt: Int, applicationPackage: String)
-    fun onInstallApplicationError(device: Device, attempt: Int, applicationPackage: String)
-    fun onInstallApplicationFailure(device: Device, applicationPackage: String, throwable: Throwable)
+    fun onInstallApplicationSuccess(device: Device, attempt: Int, applicationPackage: String, durationMs: Long)
+    fun onInstallApplicationError(
+        device: Device,
+        attempt: Int,
+        applicationPackage: String,
+        throwable: Throwable,
+        durationMs: Long
+    )
 
-    fun onGetAliveDeviceSuccess(device: Device, attempt: Int)
-    fun onGetAliveDeviceError(device: Device, attempt: Int)
-    fun onGetAliveDeviceFailed(device: Device, throwable: Throwable)
+    fun onInstallApplicationFailure(device: Device, applicationPackage: String, throwable: Throwable, durationMs: Long)
 
-    fun onClearPackageSuccess(device: Device, attempt: Int, name: String)
-    fun onClearPackageError(device: Device, attempt: Int, name: String, throwable: Throwable)
-    fun onClearPackageFailure(device: Device, name: String, throwable: Throwable)
+    fun onGetAliveDeviceSuccess(device: Device, attempt: Int, durationMs: Long)
+    fun onGetAliveDeviceError(device: Device, attempt: Int, durationMs: Long)
+    fun onGetAliveDeviceFailed(device: Device, throwable: Throwable, durationMs: Long)
 
-    fun onPullSuccess(device: Device, from: Path, to: Path)
-    fun onPullError(device: Device, attempt: Int, from: Path, throwable: Throwable)
-    fun onPullFailure(device: Device, from: Path, throwable: Throwable)
+    fun onClearPackageSuccess(device: Device, attempt: Int, name: String, durationMs: Long)
+    fun onClearPackageError(device: Device, attempt: Int, name: String, throwable: Throwable, durationMs: Long)
+    fun onClearPackageFailure(device: Device, name: String, throwable: Throwable, durationMs: Long)
 
-    fun onClearDirectorySuccess(device: Device, remotePath: Path, output: String)
-    fun onClearDirectoryError(device: Device, attempt: Int, remotePath: Path, throwable: Throwable)
-    fun onClearDirectoryFailure(device: Device, remotePath: Path, throwable: Throwable)
+    fun onPullSuccess(device: Device, from: Path, to: Path, durationMs: Long)
+    fun onPullError(device: Device, attempt: Int, from: Path, throwable: Throwable, durationMs: Long)
+    fun onPullFailure(device: Device, from: Path, throwable: Throwable, durationMs: Long)
 
-    fun onListSuccess(device: Device, remotePath: String)
-    fun onListError(device: Device, attempt: Int, remotePath: String, throwable: Throwable)
-    fun onListFailure(device: Device, remotePath: String, throwable: Throwable)
+    fun onClearDirectorySuccess(device: Device, remotePath: Path, output: String, durationMs: Long)
+    fun onClearDirectoryError(device: Device, attempt: Int, remotePath: Path, throwable: Throwable, durationMs: Long)
+    fun onClearDirectoryFailure(device: Device, remotePath: Path, throwable: Throwable, durationMs: Long)
 
-    fun onRunTestPassed(device: Device, testName: String)
-    fun onRunTestIgnored(device: Device, testName: String)
-    fun onRunTestRunError(device: Device, testName: String, errorMessage: String)
-    fun onRunTestInfrastructureError(device: Device, testName: String, errorMessage: String, throwable: Throwable?)
-    fun onRunTestFailedOnStart(device: Device, message: String)
-    fun onRunTestFailedOnInstrumentationParse(device: Device, message: String, throwable: Throwable)
+    fun onListSuccess(device: Device, remotePath: String, durationMs: Long)
+    fun onListError(device: Device, attempt: Int, remotePath: String, throwable: Throwable, durationMs: Long)
+    fun onListFailure(device: Device, remotePath: String, throwable: Throwable, durationMs: Long)
+
+    fun onRunTestPassed(device: Device, testName: String, durationMs: Long)
+    fun onRunTestIgnored(device: Device, testName: String, durationMs: Long)
+    fun onRunTestRunError(device: Device, testName: String, errorMessage: String, durationMs: Long)
+    fun onRunTestInfrastructureError(
+        device: Device,
+        testName: String,
+        errorMessage: String,
+        throwable: Throwable?,
+        durationMs: Long
+    )
+
+    fun onRunTestFailedOnStart(device: Device, message: String, durationMs: Long)
+    fun onRunTestFailedOnInstrumentationParse(device: Device, message: String, throwable: Throwable, durationMs: Long)
 }

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceEventsLogger.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceEventsLogger.kt
@@ -6,22 +6,23 @@ import java.nio.file.Path
 
 internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEventsListener {
 
-    override fun onGetSdkPropertySuccess(attempt: Int, api: Int) {
+    override fun onGetSdkPropertySuccess(attempt: Int, api: Int, durationMs: Long) {
         logger.debug("Got ro.build.version.sdk = $api")
     }
 
-    override fun onGetSdkPropertyError(attempt: Int) {
+    override fun onGetSdkPropertyError(attempt: Int, durationMs: Long) {
         logger.debug("Attempt $attempt: reading ro.build.version.sdk failed")
     }
 
-    override fun onGetSdkPropertyFailure(throwable: Throwable) {
+    override fun onGetSdkPropertyFailure(throwable: Throwable, durationMs: Long) {
         logger.warn("Failed reading ro.build.version.sdk", throwable)
     }
 
     override fun onInstallApplicationSuccess(
         device: Device,
         attempt: Int,
-        applicationPackage: String
+        applicationPackage: String,
+        durationMs: Long
     ) {
         logger.debug("Attempt $attempt: application $applicationPackage installed")
     }
@@ -29,7 +30,9 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onInstallApplicationError(
         device: Device,
         attempt: Int,
-        applicationPackage: String
+        applicationPackage: String,
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.debug("Attempt $attempt: failed to install application $applicationPackage")
     }
@@ -37,28 +40,32 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onInstallApplicationFailure(
         device: Device,
         applicationPackage: String,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.warn("Failed to install application package: $applicationPackage", throwable)
     }
 
     override fun onGetAliveDeviceSuccess(
         device: Device,
-        attempt: Int
+        attempt: Int,
+        durationMs: Long
     ) {
         logger.debug("Device status: alive")
     }
 
     override fun onGetAliveDeviceError(
         device: Device,
-        attempt: Int
+        attempt: Int,
+        durationMs: Long
     ) {
         logger.debug("Attempt $attempt: failed to determine the device status")
     }
 
     override fun onGetAliveDeviceFailed(
         device: Device,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.warn("Failed reading device status", throwable)
     }
@@ -66,7 +73,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onClearPackageSuccess(
         device: Device,
         attempt: Int,
-        name: String
+        name: String,
+        durationMs: Long
     ) {
         logger.debug("Attempt: $attempt: clear package $name completed")
     }
@@ -75,7 +83,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
         device: Device,
         attempt: Int,
         name: String,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.debug("Attempt $attempt: failed to clear package $name")
     }
@@ -83,7 +92,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onClearPackageFailure(
         device: Device,
         name: String,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.warn("Failed to clear package $name", throwable)
     }
@@ -91,7 +101,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onPullSuccess(
         device: Device,
         from: Path,
-        to: Path
+        to: Path,
+        durationMs: Long
     ) {
         logger.debug("Pull success from: $from to $to")
     }
@@ -100,7 +111,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
         device: Device,
         attempt: Int,
         from: Path,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.debug("Attempt $attempt: failed to pull $from")
     }
@@ -108,7 +120,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onPullFailure(
         device: Device,
         from: Path,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.warn("Failed pulling data $from", throwable)
     }
@@ -116,7 +129,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onClearDirectorySuccess(
         device: Device,
         remotePath: Path,
-        output: String
+        output: String,
+        durationMs: Long
     ) {
         logger.debug("Successfully cleared $remotePath. ($output)")
     }
@@ -125,7 +139,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
         device: Device,
         attempt: Int,
         remotePath: Path,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.debug("Attempt $attempt: failed to clear $remotePath")
     }
@@ -133,14 +148,16 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onClearDirectoryFailure(
         device: Device,
         remotePath: Path,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.warn("Failed clearing directory $remotePath", throwable)
     }
 
     override fun onListSuccess(
         device: Device,
-        remotePath: String
+        remotePath: String,
+        durationMs: Long
     ) {
         logger.debug("Listing $remotePath success")
     }
@@ -149,7 +166,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
         device: Device,
         attempt: Int,
         remotePath: String,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.debug("Attempt $attempt: failed to list directory $remotePath")
     }
@@ -157,14 +175,16 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onListFailure(
         device: Device,
         remotePath: String,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.warn("Failed listing path $remotePath", throwable)
     }
 
     override fun onRunTestFailedOnStart(
         device: Device,
-        message: String
+        message: String,
+        durationMs: Long
     ) {
         logger.warn("Run test failed on start: $message")
     }
@@ -172,21 +192,24 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onRunTestFailedOnInstrumentationParse(
         device: Device,
         message: String,
-        throwable: Throwable
+        throwable: Throwable,
+        durationMs: Long
     ) {
         logger.warn("Run test failed on instrumentation parse: $message", throwable)
     }
 
     override fun onRunTestPassed(
         device: Device,
-        testName: String
+        testName: String,
+        durationMs: Long
     ) {
         logger.debug("Run test passed: $testName")
     }
 
     override fun onRunTestIgnored(
         device: Device,
-        testName: String
+        testName: String,
+        durationMs: Long
     ) {
         logger.debug("Run test ignored: $testName")
     }
@@ -194,7 +217,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
     override fun onRunTestRunError(
         device: Device,
         testName: String,
-        errorMessage: String
+        errorMessage: String,
+        durationMs: Long
     ) {
         logger.warn("Run test error: $testName ($errorMessage)")
     }
@@ -203,7 +227,8 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
         device: Device,
         testName: String,
         errorMessage: String,
-        throwable: Throwable?
+        throwable: Throwable?,
+        durationMs: Long
     ) {
         logger.warn("Run test infrastructure error: $testName ($errorMessage)", throwable)
     }

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceMetrics.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceMetrics.kt
@@ -1,8 +1,8 @@
 package com.avito.runner.service.worker.device.adb.listener
 
-import com.avito.android.stats.CountMetric
 import com.avito.android.stats.SeriesName
 import com.avito.android.stats.StatsDSender
+import com.avito.android.stats.TimeMetric
 import com.avito.runner.service.worker.device.Device
 import java.nio.file.Path
 
@@ -13,117 +13,151 @@ class AdbDeviceMetrics(
 
     private val prefix = runnerPrefix.append("adb")
 
-    override fun onGetSdkPropertySuccess(attempt: Int, api: Int) {
-        statsDSender.send(CountMetric(prefix.append("get-sdk-property", "success")))
+    override fun onGetSdkPropertySuccess(attempt: Int, api: Int, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefix.append("get-sdk-property", "success"), durationMs))
     }
 
-    override fun onGetSdkPropertyError(attempt: Int) {
-        statsDSender.send(CountMetric(prefix.append("get-sdk-property", "error")))
+    override fun onGetSdkPropertyError(attempt: Int, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefix.append("get-sdk-property", "error"), durationMs))
     }
 
-    override fun onGetSdkPropertyFailure(throwable: Throwable) {
-        statsDSender.send(CountMetric(prefix.append("get-sdk-property", "failure")))
+    override fun onGetSdkPropertyFailure(throwable: Throwable, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefix.append("get-sdk-property", "failure"), durationMs))
     }
 
-    override fun onInstallApplicationSuccess(device: Device, attempt: Int, applicationPackage: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("install-application", "success")))
+    override fun onInstallApplicationSuccess(
+        device: Device,
+        attempt: Int,
+        applicationPackage: String,
+        durationMs: Long
+    ) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("install-application", "success"), durationMs))
     }
 
-    override fun onInstallApplicationError(device: Device, attempt: Int, applicationPackage: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("install-application", "error")))
+    override fun onInstallApplicationError(
+        device: Device,
+        attempt: Int,
+        applicationPackage: String,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("install-application", "error"), durationMs))
     }
 
-    override fun onInstallApplicationFailure(device: Device, applicationPackage: String, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("install-application", "failure")))
+    override fun onInstallApplicationFailure(
+        device: Device,
+        applicationPackage: String,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("install-application", "failure"), durationMs))
     }
 
-    override fun onGetAliveDeviceSuccess(device: Device, attempt: Int) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("get-alive-device", "success")))
+    override fun onGetAliveDeviceSuccess(device: Device, attempt: Int, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("get-alive-device", "success"), durationMs))
     }
 
-    override fun onGetAliveDeviceError(device: Device, attempt: Int) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("get-alive-device", "error")))
+    override fun onGetAliveDeviceError(device: Device, attempt: Int, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("get-alive-device", "error"), durationMs))
     }
 
-    override fun onGetAliveDeviceFailed(device: Device, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("get-alive-device", "failure")))
+    override fun onGetAliveDeviceFailed(device: Device, throwable: Throwable, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("get-alive-device", "failure"), durationMs))
     }
 
-    override fun onClearPackageSuccess(device: Device, attempt: Int, name: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("clear-package", "success")))
+    override fun onClearPackageSuccess(device: Device, attempt: Int, name: String, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("clear-package", "success"), durationMs))
     }
 
-    override fun onClearPackageError(device: Device, attempt: Int, name: String, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("clear-package", "error")))
+    override fun onClearPackageError(
+        device: Device,
+        attempt: Int,
+        name: String,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("clear-package", "error"), durationMs))
     }
 
-    override fun onClearPackageFailure(device: Device, name: String, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("clear-package", "failure")))
+    override fun onClearPackageFailure(device: Device, name: String, throwable: Throwable, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("clear-package", "failure"), durationMs))
     }
 
-    override fun onPullSuccess(device: Device, from: Path, to: Path) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("pull", "success")))
+    override fun onPullSuccess(device: Device, from: Path, to: Path, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("pull", "success"), durationMs))
     }
 
-    override fun onPullError(device: Device, attempt: Int, from: Path, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("pull", "error")))
+    override fun onPullError(device: Device, attempt: Int, from: Path, throwable: Throwable, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("pull", "error"), durationMs))
     }
 
-    override fun onPullFailure(device: Device, from: Path, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("pull", "failure")))
+    override fun onPullFailure(device: Device, from: Path, throwable: Throwable, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("pull", "failure"), durationMs))
     }
 
-    override fun onClearDirectorySuccess(device: Device, remotePath: Path, output: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("clear-directory", "success")))
+    override fun onClearDirectorySuccess(device: Device, remotePath: Path, output: String, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("clear-directory", "success"), durationMs))
     }
 
-    override fun onClearDirectoryError(device: Device, attempt: Int, remotePath: Path, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("clear-directory", "error")))
+    override fun onClearDirectoryError(
+        device: Device,
+        attempt: Int,
+        remotePath: Path,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("clear-directory", "error"), durationMs))
     }
 
-    override fun onClearDirectoryFailure(device: Device, remotePath: Path, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("clear-directory", "failure")))
+    override fun onClearDirectoryFailure(device: Device, remotePath: Path, throwable: Throwable, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("clear-directory", "failure"), durationMs))
     }
 
-    override fun onListSuccess(device: Device, remotePath: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("list", "success")))
+    override fun onListSuccess(device: Device, remotePath: String, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("list", "success"), durationMs))
     }
 
-    override fun onListError(device: Device, attempt: Int, remotePath: String, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("list", "error")))
+    override fun onListError(device: Device, attempt: Int, remotePath: String, throwable: Throwable, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("list", "error"), durationMs))
     }
 
-    override fun onListFailure(device: Device, remotePath: String, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("list", "failure")))
+    override fun onListFailure(device: Device, remotePath: String, throwable: Throwable, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("list", "failure"), durationMs))
     }
 
-    override fun onRunTestPassed(device: Device, testName: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("run-test", "passed")))
+    override fun onRunTestPassed(device: Device, testName: String, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("run-test", "passed"), durationMs))
     }
 
-    override fun onRunTestIgnored(device: Device, testName: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("run-test", "ignored")))
+    override fun onRunTestIgnored(device: Device, testName: String, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("run-test", "ignored"), durationMs))
     }
 
-    override fun onRunTestRunError(device: Device, testName: String, errorMessage: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("run-test", "error")))
+    override fun onRunTestRunError(device: Device, testName: String, errorMessage: String, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("run-test", "error"), durationMs))
     }
 
     override fun onRunTestInfrastructureError(
         device: Device,
         testName: String,
         errorMessage: String,
-        throwable: Throwable?
+        throwable: Throwable?,
+        durationMs: Long
     ) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("run-test", "infrastructure-error")))
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("run-test", "infrastructure-error"), durationMs))
     }
 
-    override fun onRunTestFailedOnStart(device: Device, message: String) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("run-test", "failed-on-start")))
+    override fun onRunTestFailedOnStart(device: Device, message: String, durationMs: Long) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("run-test", "failed-on-start"), durationMs))
     }
 
-    override fun onRunTestFailedOnInstrumentationParse(device: Device, message: String, throwable: Throwable) {
-        statsDSender.send(CountMetric(prefixWithDevice(device).append("run-test", "failed-instrum-parse")))
+    override fun onRunTestFailedOnInstrumentationParse(
+        device: Device,
+        message: String,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        statsDSender.send(TimeMetric(prefixWithDevice(device).append("run-test", "failed-instrum-parse"), durationMs))
     }
 
     private fun prefixWithDevice(device: Device): SeriesName {

--- a/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/CompositeAdbDeviceEventListener.kt
+++ b/subprojects/gradle/runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/CompositeAdbDeviceEventListener.kt
@@ -7,116 +7,158 @@ internal class CompositeAdbDeviceEventListener(
     private val listeners: List<AdbDeviceEventsListener>
 ) : AdbDeviceEventsListener {
 
-    override fun onGetSdkPropertySuccess(attempt: Int, api: Int) {
-        listeners.forEach { it.onGetSdkPropertySuccess(attempt, api) }
+    override fun onGetSdkPropertySuccess(attempt: Int, api: Int, durationMs: Long) {
+        listeners.forEach { it.onGetSdkPropertySuccess(attempt, api, durationMs) }
     }
 
-    override fun onGetSdkPropertyError(attempt: Int) {
-        listeners.forEach { it.onGetSdkPropertyError(attempt) }
+    override fun onGetSdkPropertyError(attempt: Int, durationMs: Long) {
+        listeners.forEach { it.onGetSdkPropertyError(attempt, durationMs) }
     }
 
-    override fun onGetSdkPropertyFailure(throwable: Throwable) {
-        listeners.forEach { it.onGetSdkPropertyFailure(throwable) }
+    override fun onGetSdkPropertyFailure(throwable: Throwable, durationMs: Long) {
+        listeners.forEach { it.onGetSdkPropertyFailure(throwable, durationMs) }
     }
 
-    override fun onInstallApplicationSuccess(device: Device, attempt: Int, applicationPackage: String) {
-        listeners.forEach { it.onInstallApplicationSuccess(device, attempt, applicationPackage) }
+    override fun onInstallApplicationSuccess(
+        device: Device,
+        attempt: Int,
+        applicationPackage: String,
+        durationMs: Long
+    ) {
+        listeners.forEach { it.onInstallApplicationSuccess(device, attempt, applicationPackage, durationMs) }
     }
 
-    override fun onInstallApplicationError(device: Device, attempt: Int, applicationPackage: String) {
-        listeners.forEach { it.onInstallApplicationError(device, attempt, applicationPackage) }
+    override fun onInstallApplicationError(
+        device: Device,
+        attempt: Int,
+        applicationPackage: String,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        listeners.forEach { it.onInstallApplicationError(device, attempt, applicationPackage, throwable, durationMs) }
     }
 
-    override fun onInstallApplicationFailure(device: Device, applicationPackage: String, throwable: Throwable) {
-        listeners.forEach { it.onInstallApplicationFailure(device, applicationPackage, throwable) }
+    override fun onInstallApplicationFailure(
+        device: Device,
+        applicationPackage: String,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        listeners.forEach { it.onInstallApplicationFailure(device, applicationPackage, throwable, durationMs) }
     }
 
-    override fun onGetAliveDeviceSuccess(device: Device, attempt: Int) {
-        listeners.forEach { it.onGetAliveDeviceSuccess(device, attempt) }
+    override fun onGetAliveDeviceSuccess(device: Device, attempt: Int, durationMs: Long) {
+        listeners.forEach { it.onGetAliveDeviceSuccess(device, attempt, durationMs) }
     }
 
-    override fun onGetAliveDeviceError(device: Device, attempt: Int) {
-        listeners.forEach { it.onGetAliveDeviceError(device, attempt) }
+    override fun onGetAliveDeviceError(device: Device, attempt: Int, durationMs: Long) {
+        listeners.forEach { it.onGetAliveDeviceError(device, attempt, durationMs) }
     }
 
-    override fun onGetAliveDeviceFailed(device: Device, throwable: Throwable) {
-        listeners.forEach { it.onGetAliveDeviceFailed(device, throwable) }
+    override fun onGetAliveDeviceFailed(device: Device, throwable: Throwable, durationMs: Long) {
+        listeners.forEach { it.onGetAliveDeviceFailed(device, throwable, durationMs) }
     }
 
-    override fun onClearPackageSuccess(device: Device, attempt: Int, name: String) {
-        listeners.forEach { it.onClearPackageSuccess(device, attempt, name) }
+    override fun onClearPackageSuccess(device: Device, attempt: Int, name: String, durationMs: Long) {
+        listeners.forEach { it.onClearPackageSuccess(device, attempt, name, durationMs) }
     }
 
-    override fun onClearPackageError(device: Device, attempt: Int, name: String, throwable: Throwable) {
-        listeners.forEach { it.onClearPackageError(device, attempt, name, throwable) }
+    override fun onClearPackageError(
+        device: Device,
+        attempt: Int,
+        name: String,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        listeners.forEach { it.onClearPackageError(device, attempt, name, throwable, durationMs) }
     }
 
-    override fun onClearPackageFailure(device: Device, name: String, throwable: Throwable) {
-        listeners.forEach { it.onClearPackageFailure(device, name, throwable) }
+    override fun onClearPackageFailure(device: Device, name: String, throwable: Throwable, durationMs: Long) {
+        listeners.forEach { it.onClearPackageFailure(device, name, throwable, durationMs) }
     }
 
-    override fun onPullSuccess(device: Device, from: Path, to: Path) {
-        listeners.forEach { it.onPullSuccess(device, from, to) }
+    override fun onPullSuccess(device: Device, from: Path, to: Path, durationMs: Long) {
+        listeners.forEach { it.onPullSuccess(device, from, to, durationMs) }
     }
 
-    override fun onPullError(device: Device, attempt: Int, from: Path, throwable: Throwable) {
-        listeners.forEach { it.onPullError(device, attempt, from, throwable) }
+    override fun onPullError(device: Device, attempt: Int, from: Path, throwable: Throwable, durationMs: Long) {
+        listeners.forEach { it.onPullError(device, attempt, from, throwable, durationMs) }
     }
 
-    override fun onPullFailure(device: Device, from: Path, throwable: Throwable) {
-        listeners.forEach { it.onPullFailure(device, from, throwable) }
+    override fun onPullFailure(device: Device, from: Path, throwable: Throwable, durationMs: Long) {
+        listeners.forEach { it.onPullFailure(device, from, throwable, durationMs) }
     }
 
-    override fun onClearDirectorySuccess(device: Device, remotePath: Path, output: String) {
-        listeners.forEach { it.onClearDirectorySuccess(device, remotePath, output) }
+    override fun onClearDirectorySuccess(device: Device, remotePath: Path, output: String, durationMs: Long) {
+        listeners.forEach { it.onClearDirectorySuccess(device, remotePath, output, durationMs) }
     }
 
-    override fun onClearDirectoryError(device: Device, attempt: Int, remotePath: Path, throwable: Throwable) {
-        listeners.forEach { it.onClearDirectoryError(device, attempt, remotePath, throwable) }
+    override fun onClearDirectoryError(
+        device: Device,
+        attempt: Int,
+        remotePath: Path,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        listeners.forEach { it.onClearDirectoryError(device, attempt, remotePath, throwable, durationMs) }
     }
 
-    override fun onClearDirectoryFailure(device: Device, remotePath: Path, throwable: Throwable) {
-        listeners.forEach { it.onClearDirectoryFailure(device, remotePath, throwable) }
+    override fun onClearDirectoryFailure(device: Device, remotePath: Path, throwable: Throwable, durationMs: Long) {
+        listeners.forEach { it.onClearDirectoryFailure(device, remotePath, throwable, durationMs) }
     }
 
-    override fun onListSuccess(device: Device, remotePath: String) {
-        listeners.forEach { it.onListSuccess(device, remotePath) }
+    override fun onListSuccess(device: Device, remotePath: String, durationMs: Long) {
+        listeners.forEach { it.onListSuccess(device, remotePath, durationMs) }
     }
 
-    override fun onListError(device: Device, attempt: Int, remotePath: String, throwable: Throwable) {
-        listeners.forEach { it.onListError(device, attempt, remotePath, throwable) }
+    override fun onListError(device: Device, attempt: Int, remotePath: String, throwable: Throwable, durationMs: Long) {
+        listeners.forEach { it.onListError(device, attempt, remotePath, throwable, durationMs) }
     }
 
-    override fun onListFailure(device: Device, remotePath: String, throwable: Throwable) {
-        listeners.forEach { it.onListFailure(device, remotePath, throwable) }
+    override fun onListFailure(device: Device, remotePath: String, throwable: Throwable, durationMs: Long) {
+        listeners.forEach { it.onListFailure(device, remotePath, throwable, durationMs) }
     }
 
-    override fun onRunTestPassed(device: Device, testName: String) {
-        listeners.forEach { it.onRunTestPassed(device, testName) }
+    override fun onRunTestPassed(device: Device, testName: String, durationMs: Long) {
+        listeners.forEach { it.onRunTestPassed(device, testName, durationMs) }
     }
 
-    override fun onRunTestIgnored(device: Device, testName: String) {
-        listeners.forEach { it.onRunTestIgnored(device, testName) }
+    override fun onRunTestIgnored(device: Device, testName: String, durationMs: Long) {
+        listeners.forEach { it.onRunTestIgnored(device, testName, durationMs) }
     }
 
-    override fun onRunTestRunError(device: Device, testName: String, errorMessage: String) {
-        listeners.forEach { it.onRunTestRunError(device, testName, errorMessage) }
+    override fun onRunTestRunError(device: Device, testName: String, errorMessage: String, durationMs: Long) {
+        listeners.forEach { it.onRunTestRunError(device, testName, errorMessage, durationMs) }
     }
 
     override fun onRunTestInfrastructureError(
         device: Device,
         testName: String,
         errorMessage: String,
-        throwable: Throwable?
+        throwable: Throwable?,
+        durationMs: Long
     ) {
-        listeners.forEach { it.onRunTestInfrastructureError(device, testName, errorMessage, throwable) }
+        listeners.forEach {
+            it.onRunTestInfrastructureError(
+                device,
+                testName,
+                errorMessage,
+                throwable,
+                durationMs
+            )
+        }
     }
 
-    override fun onRunTestFailedOnStart(device: Device, message: String) {
-        listeners.forEach { it.onRunTestFailedOnStart(device, message) }
+    override fun onRunTestFailedOnStart(device: Device, message: String, durationMs: Long) {
+        listeners.forEach { it.onRunTestFailedOnStart(device, message, durationMs) }
     }
 
-    override fun onRunTestFailedOnInstrumentationParse(device: Device, message: String, throwable: Throwable) {
-        listeners.forEach { it.onRunTestFailedOnInstrumentationParse(device, message, throwable) }
+    override fun onRunTestFailedOnInstrumentationParse(
+        device: Device,
+        message: String,
+        throwable: Throwable,
+        durationMs: Long
+    ) {
+        listeners.forEach { it.onRunTestFailedOnInstrumentationParse(device, message, throwable, durationMs) }
     }
 }

--- a/subprojects/gradle/runner/stub/src/main/kotlin/com/avito/runner/test/StubDevice.kt
+++ b/subprojects/gradle/runner/stub/src/main/kotlin/com/avito/runner/test/StubDevice.kt
@@ -29,7 +29,7 @@ open class StubDevice(
     installApplicationResults: List<Try<DeviceInstallation>> = emptyList(),
     gettingDeviceStatusResults: List<Device.DeviceStatus> = emptyList(),
     runTestsResults: List<StubActionResult<TestCaseRun.Result>> = emptyList(),
-    clearPackageResults: List<StubActionResult<Try<Any>>> = emptyList(),
+    clearPackageResults: List<StubActionResult<Try<Unit>>> = emptyList(),
     private val apiResult: StubActionResult<Int> = StubActionResult.Success(22),
     override val online: Boolean = true,
     override val model: String = "model"
@@ -43,7 +43,7 @@ open class StubDevice(
         ArrayDeque(gettingDeviceStatusResults)
     private val runTestsResultsQueue: Queue<StubActionResult<TestCaseRun.Result>> =
         ArrayDeque(runTestsResults)
-    private val clearPackageResultsQueue: Queue<StubActionResult<Try<Any>>> =
+    private val clearPackageResultsQueue: Queue<StubActionResult<Try<Unit>>> =
         ArrayDeque(clearPackageResults)
 
     override val logger = loggerFactory.create(tag)
@@ -90,7 +90,7 @@ open class StubDevice(
         )
     }
 
-    override fun clearPackage(name: String): Try<Any> {
+    override fun clearPackage(name: String): Try<Unit> {
         resultQueuePrecondition(
             queue = clearPackageResultsQueue,
             functionName = "clearPackage",
@@ -104,7 +104,7 @@ open class StubDevice(
         return result
     }
 
-    override fun pull(from: Path, to: Path): Try<Any> {
+    override fun pull(from: Path, to: Path): Try<Unit> {
 
         logger.debug("pull called [from: $from to: $to]")
 
@@ -130,13 +130,13 @@ open class StubDevice(
 
             resultFile.writeText(gson.toJson(testRuntimeData))
 
-            Try.Success(Any())
+            Try.Success(Unit)
         } else {
-            Try.Success(Any())
+            Try.Success(Unit)
         }
     }
 
-    override fun clearDirectory(remotePath: Path): Try<Any> = Try {}
+    override fun clearDirectory(remotePath: Path): Try<Unit> = Try {}
 
     override fun list(remotePath: String): Try<List<String>> = Try { emptyList() }
 


### PR DESCRIPTION
Metrics now comes with `projectName` in prefix and removed buildId:
`testrunner.<projectName>.<instrumentationConfigName>`
was
`testrunner.<buildId>.<instrumentationConfigName>`
It is needed to show demo apps and avito project metrics separately

All adb metrics are type=time now

Also added custom `Result` type to replace `Funktionale` until `kotlin.Result` goes stable

TODO

- [x] remove buildId from Metric