### PR TITLE
Collect data about common dependencies between apps

### DIFF
--- a/subprojects/gradle/module-dependencies-graph/build.gradle.kts
+++ b/subprojects/gradle/module-dependencies-graph/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     compileOnly(gradleApi())
 
     implementation(project(":gradle:gradle-logger"))
+    implementation(project(":common:math"))
 
     gradleTestImplementation(project(":common:truth-extensions"))
     gradleTestImplementation(testFixtures(project(":common:logger")))

--- a/subprojects/gradle/module-dependencies-graph/src/gradleTest/kotlin/com/avito/module/metrics/CollectAppsMetricsActionTest.kt
+++ b/subprojects/gradle/module-dependencies-graph/src/gradleTest/kotlin/com/avito/module/metrics/CollectAppsMetricsActionTest.kt
@@ -1,0 +1,98 @@
+package com.avito.module.metrics
+
+import com.avito.logger.StubLoggerFactory
+import com.avito.module.dependencies.androidApp
+import com.avito.module.dependencies.androidLib
+import com.avito.module.dependencies.rootProject
+import com.avito.module.internal.dependencies.AndroidAppsGraphBuilder
+import com.avito.module.internal.dependencies.DependenciesGraphBuilder
+import com.avito.module.metrics.metrics.AppsHealthData
+import com.avito.module.metrics.metrics.CollectAppsMetricsAction
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.Project
+import org.gradle.util.Path
+import org.junit.jupiter.api.Test
+
+@Suppress("MagicNumber")
+internal class CollectAppsMetricsActionTest {
+
+    @Test
+    fun `relative - no common modules`() {
+        val root = rootProject()
+
+        val lib = androidLib("lib", parent = root)
+
+        val appA = androidApp("app-a", parent = root)
+        appA.dependencies.add("implementation", lib)
+
+        androidApp("app-b", parent = root)
+
+        val relativeMetrics = collectMetrics(root).relative
+
+        val aToB = relativeMetrics.getOrNull(Path.path(":app-a"), Path.path(":app-b"))
+        assertThat(aToB!!.commonDependenciesRatio.toInt()).isEqualTo(0)
+
+        val bToA = relativeMetrics.getOrNull(Path.path(":app-b"), Path.path(":app-a"))
+        assertThat(bToA!!.commonDependenciesRatio.toInt()).isEqualTo(0)
+    }
+
+    @Test
+    fun `relative - all common modules`() {
+        val root = rootProject()
+
+        val lib = androidLib("lib", parent = root)
+
+        val appA = androidApp("app-a", parent = root)
+        appA.dependencies.add("implementation", lib)
+
+        val appB = androidApp("app-b", parent = root)
+        appB.dependencies.add("implementation", lib)
+
+        val relativeMetrics = collectMetrics(root).relative
+
+        val aToB = relativeMetrics.getOrNull(Path.path(":app-a"), Path.path(":app-b"))
+        assertThat(aToB!!.commonDependenciesRatio.toInt()).isEqualTo(100)
+
+        val bToA = relativeMetrics.getOrNull(Path.path(":app-b"), Path.path(":app-a"))
+        assertThat(bToA!!.commonDependenciesRatio.toInt()).isEqualTo(100)
+    }
+
+    @Test
+    fun `relative - partial intersection`() {
+        val root = rootProject()
+
+        val libA = androidLib("libA", parent = root)
+        val libB = androidLib("libB", parent = root)
+        val libC = androidLib("libC", parent = root)
+        val libD = androidLib("libD", parent = root)
+        val libE = androidLib("libE", parent = root)
+        val libF = androidLib("libF", parent = root)
+
+        val appA = androidApp("app-a", parent = root)
+        appA.dependencies.add("implementation", libA)
+        appA.dependencies.add("implementation", libB)
+        appA.dependencies.add("implementation", libC)
+        appA.dependencies.add("implementation", libD)
+        appA.dependencies.add("implementation", libE)
+
+        val appB = androidApp("app-b", parent = root)
+        appB.dependencies.add("implementation", libD)
+        appB.dependencies.add("implementation", libE)
+        appB.dependencies.add("implementation", libF)
+
+        val relativeMetrics = collectMetrics(root).relative
+
+        val aToB = relativeMetrics.getOrNull(Path.path(":app-a"), Path.path(":app-b"))
+        assertThat(aToB!!.commonDependenciesRatio.toInt()).isEqualTo(40)
+
+        val bToA = relativeMetrics.getOrNull(Path.path(":app-b"), Path.path(":app-a"))
+        assertThat(bToA!!.commonDependenciesRatio.toInt()).isEqualTo(66)
+    }
+
+    private fun collectMetrics(root: Project): AppsHealthData {
+        val graphBuilder = DependenciesGraphBuilder(root, StubLoggerFactory)
+        val androidGraphBuilder = AndroidAppsGraphBuilder(graphBuilder)
+
+        return CollectAppsMetricsAction(androidGraphBuilder).collect()
+    }
+}

--- a/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/dependencies/ModuleDependenciesGraphPlugin.kt
+++ b/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/dependencies/ModuleDependenciesGraphPlugin.kt
@@ -1,5 +1,6 @@
 package com.avito.module.dependencies
 
+import com.avito.module.metrics.CollectAppsMetricsTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -11,5 +12,10 @@ public class ModuleDependenciesGraphPlugin : Plugin<Project> {
             "must be applied to the root project"
         }
         target.tasks.register("findAndroidApp", FindAndroidAppTask::class.java)
+        target.tasks.register("collectAppsMetrics", CollectAppsMetricsTask::class.java) {
+            it.outputs.upToDateWhen {
+                false // heavy to calculate correct inputs
+            }
+        }
     }
 }

--- a/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/metrics/CollectAppsMetricsTask.kt
+++ b/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/metrics/CollectAppsMetricsTask.kt
@@ -1,0 +1,116 @@
+package com.avito.module.metrics
+
+import com.avito.logger.GradleLoggerFactory
+import com.avito.logger.Logger
+import com.avito.logger.create
+import com.avito.module.internal.dependencies.AndroidAppsGraphBuilder
+import com.avito.module.internal.dependencies.DependenciesGraphBuilder
+import com.avito.module.metrics.metrics.AbsoluteMetrics
+import com.avito.module.metrics.metrics.CollectAppsMetricsAction
+import com.avito.module.metrics.metrics.Matrix
+import com.avito.module.metrics.metrics.RelativeMetrics
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFile
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.util.Path
+import java.io.File
+import javax.inject.Inject
+
+@Suppress("UnstableApiUsage")
+public abstract class CollectAppsMetricsTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask() {
+
+    private val logger: Logger = GradleLoggerFactory.fromTask(this).create<CollectAppsMetricsTask>()
+
+    init {
+        description = "Collect Android applications modules health metrics"
+    }
+
+    private val outputDir = File(project.buildDir, "reports/app-modules-health")
+
+    @OutputFile
+    public val uniqueAppsMetrics: Property<RegularFile> = objects.fileProperty().apply {
+        set(File(outputDir, "apps.csv"))
+    }
+
+    @OutputFile
+    public val commonModulesComparison: Property<RegularFile> = objects.fileProperty().apply {
+        set(File(outputDir, "apps-common-modules-comparison.csv"))
+    }
+
+    @OutputFile
+    public val commonModulesDetails: Property<RegularFile> = objects.fileProperty().apply {
+        set(File(outputDir, "apps-common-modules-details.log"))
+    }
+
+    @TaskAction
+    public fun action() {
+        val graphBuilder = DependenciesGraphBuilder(project.rootProject, GradleLoggerFactory.fromTask(this))
+        val androidAppsGraphBuilder = AndroidAppsGraphBuilder(graphBuilder)
+
+        val data = CollectAppsMetricsAction(androidAppsGraphBuilder).collect()
+        writeAbsolute(data.absolute)
+        writeRelative(data.relative)
+        writeDetails(data.relative)
+
+        logger.info("Wrote results to $outputDir")
+    }
+
+    private fun writeAbsolute(data: Map<Path, AbsoluteMetrics>) {
+        val file = uniqueAppsMetrics.get().asFile
+        file.writeText("module;all dependencies\n")
+        data.forEach { (path, metrics) ->
+            file.appendText("$path;${metrics.allDependencies}\n")
+        }
+    }
+
+    private fun writeRelative(data: Matrix<Path, RelativeMetrics>) {
+        val file = commonModulesComparison.get().asFile
+        val columns: List<Path> = data.columnsCoordinates().toList()
+        file.writeText(
+            "module;" + columns.joinToString(separator = ";", postfix = "\n") { it.toString() }
+        )
+        data.rowsCoordinates().forEach { compared ->
+            val values = columns
+                .map { baseline ->
+                    data.getOrNull(baseline, compared)
+                }
+                .joinToString(separator = ";", postfix = "\n") { metrics ->
+                    metrics?.commonDependenciesRatio?.toInt().toString()
+                }
+            file.appendText("$compared;$values")
+        }
+    }
+
+    private fun writeDetails(data: Matrix<Path, RelativeMetrics>) {
+        val file = commonModulesDetails.get().asFile
+
+        data.rowsCoordinates().forEach { comparedApp ->
+            data.columnsCoordinates().map { baselineApp ->
+                val metrics = data.getOrNull(baselineApp, comparedApp)
+                if (metrics != null) {
+                    val appDetails = """
+                    |===
+                    |Comparison of $baselineApp against $comparedApp
+                    |
+                    |$baselineApp has ${metrics.baselineDependencies.size} dependencies
+                    |$comparedApp has ${metrics.comparedDependencies.size} dependencies
+                    |
+                    |${metrics.commonDependenciesRatio} of $baselineApp dependencies are common with $comparedApp
+                    |
+                    |Unique dependencies in $baselineApp: 
+                    |${metrics.uniqueDependencies}
+                    |
+                    |Common dependencies between $baselineApp and $comparedApp: 
+                    |${metrics.commonDependencies}
+                    |""".trimMargin()
+                    file.appendText(appDetails)
+                }
+            }
+        }
+    }
+}

--- a/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/metrics/metrics/AppsHealthData.kt
+++ b/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/metrics/metrics/AppsHealthData.kt
@@ -1,0 +1,39 @@
+package com.avito.module.metrics.metrics
+
+import com.avito.math.Percent
+import com.avito.math.percentOf
+import org.gradle.util.Path
+
+internal data class AppsHealthData(
+    val absolute: Map<Path, AbsoluteMetrics>,
+    val relative: Matrix<Path, RelativeMetrics>
+)
+
+internal class AbsoluteMetrics(
+    val allDependencies: Int
+)
+
+internal class RelativeMetrics(
+    val baselineDependencies: Set<Path>,
+    val comparedDependencies: Set<Path>,
+) {
+
+    val commonDependencies: Set<Path>
+        get() = baselineDependencies.intersect(comparedDependencies)
+
+    val uniqueDependencies: Set<Path>
+        get() = baselineDependencies.minus(commonDependencies)
+
+    /**
+     * Proportion of compared dependencies included to baseline dependencies
+     *
+     * Example:
+     * application X has modules A, B
+     * application Y has modules B
+     *
+     * X -> Y: 50% (includes 1 out of 2 dependencies)
+     * Y -> X: 100% (includes 1 out of 1)
+     */
+    val commonDependenciesRatio: Percent
+        get() = commonDependencies.size.percentOf(baselineDependencies.size)
+}

--- a/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/metrics/metrics/CollectAppsMetricsAction.kt
+++ b/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/metrics/metrics/CollectAppsMetricsAction.kt
@@ -1,0 +1,66 @@
+package com.avito.module.metrics.metrics
+
+import com.avito.module.configurations.ConfigurationType
+import com.avito.module.internal.dependencies.AndroidAppsGraphBuilder
+import com.avito.module.internal.dependencies.ProjectWithDeps
+import org.gradle.util.Path
+
+internal class CollectAppsMetricsAction(
+    private val graphBuilder: AndroidAppsGraphBuilder
+) {
+
+    fun collect(): AppsHealthData {
+        val appsWithDeps = appsWithDeps()
+
+        return AppsHealthData(
+            absolute = absoluteMetrics(appsWithDeps),
+            relative = relativeMetrics(appsWithDeps)
+        )
+    }
+
+    private fun appsWithDeps(): Set<ProjectWithDeps> {
+        return graphBuilder
+            .buildDependenciesGraph(ConfigurationType.Main)
+            .map {
+                ProjectWithDeps(it.project, it.allDependencies())
+            }
+            .toSet()
+    }
+
+    private fun absoluteMetrics(appsWithDeps: Set<ProjectWithDeps>): Map<Path, AbsoluteMetrics> {
+        return appsWithDeps
+            .map { projectWithDeps ->
+                val path = Path.path(projectWithDeps.project.path)
+                val metrics = AbsoluteMetrics(
+                    allDependencies = projectWithDeps.dependencies.size,
+                )
+                path to metrics
+            }
+            .toMap()
+    }
+
+    private fun relativeMetrics(appsWithDeps: Set<ProjectWithDeps>): Matrix<Path, RelativeMetrics> {
+        val metrics = Matrix<Path, RelativeMetrics>()
+
+        for (firstApp in appsWithDeps) {
+            for (secondApp in appsWithDeps) {
+                if (firstApp.project == secondApp.project) continue
+
+                val row = Path.path(firstApp.project.path)
+                val column = Path.path(secondApp.project.path)
+
+                metrics.putIfAbsent(row, column) {
+                    computeRelativeMetrics(firstApp, secondApp)
+                }
+            }
+        }
+        return metrics
+    }
+
+    private fun computeRelativeMetrics(first: ProjectWithDeps, second: ProjectWithDeps): RelativeMetrics {
+        return RelativeMetrics(
+            baselineDependencies = first.dependencies.map { Path.path(it.path) }.toSet(),
+            comparedDependencies = second.dependencies.map { Path.path(it.path) }.toSet()
+        )
+    }
+}

--- a/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/metrics/metrics/Matrix.kt
+++ b/subprojects/gradle/module-dependencies-graph/src/main/kotlin/com/avito/module/metrics/metrics/Matrix.kt
@@ -1,0 +1,27 @@
+package com.avito.module.metrics.metrics
+
+internal class Matrix<COORDINATE, VALUE> {
+
+    private val data = mutableMapOf<COORDINATE, MutableMap<COORDINATE, VALUE>>()
+
+    fun rowsCoordinates(): Set<COORDINATE> {
+        return data.keys
+    }
+
+    fun columnsCoordinates(): Set<COORDINATE> {
+        return rowsCoordinates().flatMap { row(it).keys }.toSet()
+    }
+
+    fun getOrNull(row: COORDINATE, column: COORDINATE): VALUE? {
+        return row(row)[column]
+    }
+
+    fun putIfAbsent(row: COORDINATE, column: COORDINATE, value: () -> VALUE) {
+        if (row(row)[column] == null) {
+            row(row)[column] = value()
+        }
+    }
+
+    private fun row(row: COORDINATE): MutableMap<COORDINATE, VALUE> =
+        data.getOrPut(row) { mutableMapOf() }
+}


### PR DESCRIPTION
Collecting data about modules dependencies to find duplications.
These are not final metrics for tracking, only extra information for further researches.

- Total dependencies in applications
- Proportion of common dependencies between applications. This shows duplicates.

The next steps are:
- Find root problems in heavy and duplicated applications
- Decide what can we do to track and fix them