### PR TITLE
Fix loss of accuracy in statsd gauge metrics

### DIFF
--- a/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSender.kt
+++ b/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSender.kt
@@ -74,13 +74,15 @@ interface StatsDSender {
             when (metric) {
                 is TimeMetric -> client.time(aspect, metric.value)
                 is CountMetric -> client.count(aspect, metric.value)
-                is GaugeMetric -> client.gauge(aspect, metric.value)
+                is GaugeMetric -> client.gauge(aspect, metric.value.toLong()) // incorrect conversion for backward compatibility
+                is GaugeLongMetric -> client.gauge(aspect, metric.value)
+                is GaugeDoubleMetric -> client.gauge(aspect, metric.value)
             }
 
             if (config is StatsDConfig.Enabled) {
                 logger.debug("${metric.type}:${config.namespace}.$aspect:${metric.value}")
             } else {
-                logger.debug("Skip sending event: $aspect")
+                logger.debug("Skip sending event: ${metric.type}:<namespace>:$aspect:${metric.value}")
             }
         }
     }

--- a/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSender.kt
+++ b/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSender.kt
@@ -71,10 +71,12 @@ interface StatsDSender {
                 metric.name
             }.toString()
 
+            @Suppress("DEPRECATION")
             when (metric) {
                 is TimeMetric -> client.time(aspect, metric.value)
                 is CountMetric -> client.count(aspect, metric.value)
-                is GaugeMetric -> client.gauge(aspect, metric.value.toLong()) // incorrect conversion for backward compatibility
+                // Incorrect conversion for backward compatibility
+                is GaugeMetric -> client.gauge(aspect, metric.value.toLong())
                 is GaugeLongMetric -> client.gauge(aspect, metric.value)
                 is GaugeDoubleMetric -> client.gauge(aspect, metric.value)
             }

--- a/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsMetric.kt
+++ b/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsMetric.kt
@@ -22,10 +22,30 @@ data class CountMetric(
     override val type = "count"
 }
 
+// TODO: delete after 2021.12
+@Deprecated(
+    "Use typed alternative: [GaugeLongMetric] or [GaugeDoubleMetric]. Statsd can't consume any Number.",
+)
 data class GaugeMetric(
     override val name: SeriesName,
     val gauge: Number
 ) : StatsMetric() {
-    override val value: Long = gauge.toLong()
+    override val value: Number = gauge
+    override val type = "gauge"
+}
+
+data class GaugeLongMetric(
+    override val name: SeriesName,
+    val gauge: Long
+) : StatsMetric() {
+    override val value: Long = gauge
+    override val type = "gauge"
+}
+
+data class GaugeDoubleMetric(
+    override val name: SeriesName,
+    val gauge: Double
+) : StatsMetric() {
+    override val value: Double = gauge
     override val type = "gauge"
 }

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/SlowTasksListener.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/SlowTasksListener.kt
@@ -4,7 +4,7 @@ import com.avito.android.gradle.profile.BuildProfile
 import com.avito.android.gradle.profile.Operation
 import com.avito.android.gradle.profile.TaskExecution
 import com.avito.android.plugin.build_metrics.BuildMetricTracker
-import com.avito.android.stats.GaugeMetric
+import com.avito.android.stats.GaugeLongMetric
 import com.avito.android.stats.SeriesName
 import com.avito.android.stats.TimeMetric
 import com.avito.math.percentOf
@@ -28,7 +28,7 @@ internal class SlowTasksListener(
             it.internalState.outcome == TaskExecutionOutcome.FROM_CACHE
         }
         val missedPercentages = executed.percentOf(executed + hits).toLong()
-        val metric = GaugeMetric(SeriesName.create("tasks", "from_cache", "miss"), missedPercentages)
+        val metric = GaugeLongMetric(SeriesName.create("tasks", "from_cache", "miss"), missedPercentages)
 
         metricTracker.track(status, metric)
 

--- a/subprojects/gradle/impact/src/main/kotlin/com/avito/impact/plugin/ImpactMetricsSender.kt
+++ b/subprojects/gradle/impact/src/main/kotlin/com/avito/impact/plugin/ImpactMetricsSender.kt
@@ -1,7 +1,7 @@
 package com.avito.impact.plugin
 
 import com.avito.android.sentry.EnvironmentInfo
-import com.avito.android.stats.GaugeMetric
+import com.avito.android.stats.GaugeLongMetric
 import com.avito.android.stats.SeriesName
 import com.avito.android.stats.StatsDSender
 import com.avito.impact.ModifiedProjectsFinder
@@ -45,15 +45,15 @@ class ImpactMetricsSender(
         modifiedProjectsFinder.getProjects().forEach { (type, projects) ->
             val modified = projects.filter { it.project.internalModule.isModified(type) }
 
-            sendMetric(type, "all", projects.size)
-            sendMetric(type, "modified", modified.size)
+            sendMetric(type, "all", projects.size.toLong())
+            sendMetric(type, "modified", modified.size.toLong())
         }
     }
 
     @Suppress("DefaultLocale")
-    private fun sendMetric(type: ConfigurationType, name: String, value: Number) {
+    private fun sendMetric(type: ConfigurationType, name: String, value: Long) {
         statsDSender.send(
-            GaugeMetric(prefix.append("impact", type.name.toLowerCase(), name), value)
+            GaugeLongMetric(prefix.append("impact", type.name.toLowerCase(), name), value)
         )
     }
 }

--- a/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/metrics/InstrumentationMetricsSender.kt
+++ b/subprojects/gradle/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/metrics/InstrumentationMetricsSender.kt
@@ -1,7 +1,7 @@
 package com.avito.instrumentation.metrics
 
 import com.avito.android.stats.CountMetric
-import com.avito.android.stats.GaugeMetric
+import com.avito.android.stats.GaugeLongMetric
 import com.avito.android.stats.SeriesName
 import com.avito.android.stats.StatsDSender
 
@@ -13,7 +13,7 @@ public class InstrumentationMetricsSender(
     private val prefix = runnerPrefix.append("tests", "status")
 
     public fun sendNotReportedCount(count: Int) {
-        statsDSender.send(GaugeMetric(prefix.append("lost.not-reported"), count))
+        statsDSender.send(GaugeLongMetric(prefix.append("lost.not-reported"), count.toLong()))
     }
 
     public fun sendReportFileParseErrors() {

--- a/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/metrics/TestMetricsSender.kt
+++ b/subprojects/gradle/runner/client/src/main/kotlin/com/avito/runner/scheduler/metrics/TestMetricsSender.kt
@@ -1,6 +1,6 @@
 package com.avito.runner.scheduler.metrics
 
-import com.avito.android.stats.GaugeMetric
+import com.avito.android.stats.GaugeLongMetric
 import com.avito.android.stats.SeriesName
 import com.avito.android.stats.StatsDSender
 
@@ -10,30 +10,30 @@ internal class TestMetricsSender(
 ) {
 
     fun sendInitialDelay(delayMs: Long) {
-        statsDSender.send(GaugeMetric(prefix.append("initial-delay"), delayMs))
+        statsDSender.send(GaugeLongMetric(prefix.append("initial-delay"), delayMs))
     }
 
     fun sendEndDelay(delayMs: Long) {
-        statsDSender.send(GaugeMetric(prefix.append("end-delay"), delayMs))
+        statsDSender.send(GaugeLongMetric(prefix.append("end-delay"), delayMs))
     }
 
     fun sendMedianQueueTime(value: Long) {
-        statsDSender.send(GaugeMetric(prefix.append("queue-median"), value))
+        statsDSender.send(GaugeLongMetric(prefix.append("queue-median"), value))
     }
 
     fun sendMedianInstallationTime(value: Long) {
-        statsDSender.send(GaugeMetric(prefix.append("install-median"), value))
+        statsDSender.send(GaugeLongMetric(prefix.append("install-median"), value))
     }
 
     fun sendSuiteTime(suiteTimeMs: Long) {
-        statsDSender.send(GaugeMetric(prefix.append("suite"), suiteTimeMs))
+        statsDSender.send(GaugeLongMetric(prefix.append("suite"), suiteTimeMs))
     }
 
     fun sendTotalTime(timeMs: Long) {
-        statsDSender.send(GaugeMetric(prefix.append("total"), timeMs))
+        statsDSender.send(GaugeLongMetric(prefix.append("total"), timeMs))
     }
 
     fun sendMedianDeviceUtilization(percent: Int) {
-        statsDSender.send(GaugeMetric(prefix.append("device-utilization.median"), percent))
+        statsDSender.send(GaugeLongMetric(prefix.append("device-utilization.median"), percent.toLong()))
     }
 }


### PR DESCRIPTION
The problem:

```kotlin
GaugeMetric("path", 0.4).value

Expected: 0.4
Actual: 0
```

I've typed the model. 
Now clients decide how to convert original values to Statsd compatible types.

```kotlin
GaugeDoubleMetric("path", 0.4)
GaugeLongMetric("path", 0.4.toLong())
```