### PR TITLE
Mbs 10889 Use infra version as a release in Sentry events

### DIFF
--- a/build-logic/publication/src/main/kotlin/convention.publish-base.gradle.kts
+++ b/build-logic/publication/src/main/kotlin/convention.publish-base.gradle.kts
@@ -11,7 +11,7 @@ version = providers.gradleProperty("projectVersion")
     .forUseAtConfigurationTime()
     .get()
 
-tasks.withType(Jar::class.java) {
+tasks.withType<Jar> {
     manifest {
         attributes(
             mapOf(

--- a/build-logic/publication/src/main/kotlin/convention.publish-base.gradle.kts
+++ b/build-logic/publication/src/main/kotlin/convention.publish-base.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.jar.Attributes
+
 plugins {
     `maven-publish`
 }
@@ -8,6 +10,16 @@ group = "com.avito.android"
 version = providers.gradleProperty("projectVersion")
     .forUseAtConfigurationTime()
     .get()
+
+tasks.withType(Jar::class.java) {
+    manifest {
+        attributes(
+            mapOf(
+                Attributes.Name.IMPLEMENTATION_VERSION.toString() to project.version
+            )
+        )
+    }
+}
 
 publishing.publications.withType<MavenPublication> {
     pom {

--- a/subprojects/common/sentry/src/main/kotlin/com/avito/android/sentry/SentryConfig.kt
+++ b/subprojects/common/sentry/src/main/kotlin/com/avito/android/sentry/SentryConfig.kt
@@ -44,7 +44,7 @@ sealed class SentryConfig : Serializable {
         val dsn: String,
         val environment: String,
         val serverName: String,
-        val release: String,
+        val release: String?,
         val tags: Map<String, String>,
         val maxStringLength: Int = DEFAULT_SENTRY_MAX_STRING
     ) : SentryConfig()

--- a/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/EnvironmentInfo.kt
+++ b/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/EnvironmentInfo.kt
@@ -19,7 +19,6 @@ import org.gradle.api.provider.Provider
 interface EnvironmentInfo { // TODO: merge with BuildEnvironment and EnvArgs
     val node: String?
     val environment: Environment
-    val commit: String?
     fun teamcityBuildId(): String?
 }
 

--- a/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/internal/EnvironmentInfoImpl.kt
+++ b/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/internal/EnvironmentInfoImpl.kt
@@ -48,18 +48,6 @@ internal class EnvironmentInfoImpl(
 
     private val hasGit: Boolean = project.buildEnvironment !is BuildEnvironment.Mirkale
 
-    override val commit: String? by lazy {
-        if (hasGit) {
-            try {
-                git.tryParseRev("HEAD").getOrThrow()
-            } catch (e: Throwable) {
-                null
-            }
-        } else {
-            null
-        }
-    }
-
     private fun userName(): String? = System.getProperty("user.name")
 
     private fun teamcityAgentName(): String? {

--- a/subprojects/gradle/build-environment/src/testFixtures/kotlin/com/avito/android/sentry/StubEnvironmentInfo.kt
+++ b/subprojects/gradle/build-environment/src/testFixtures/kotlin/com/avito/android/sentry/StubEnvironmentInfo.kt
@@ -5,7 +5,6 @@ import com.avito.utils.gradle.Environment
 class StubEnvironmentInfo(
     override val node: String? = null,
     override val environment: Environment = Environment.CI,
-    override val commit: String? = null,
     val teamcityBuildId: String? = null,
 ) : EnvironmentInfo {
 

--- a/subprojects/gradle/sentry-config/src/main/kotlin/com/avito/android/sentry/ProjectExtensions.kt
+++ b/subprojects/gradle/sentry-config/src/main/kotlin/com/avito/android/sentry/ProjectExtensions.kt
@@ -36,11 +36,13 @@ private fun from(project: Project): SentryConfig {
             tags[buildIdTag] = buildId
         }
 
+        val infraVersion = SentryConfig::class.java.`package`.implementationVersion
+
         val config = SentryConfig.Enabled(
             dsn = project.getMandatoryStringProperty("avito.sentry.dsn"),
             environment = buildEnv::class.java.simpleName,
             serverName = info.node ?: "unknown",
-            release = info.commit ?: "unknown",
+            release = infraVersion,
             tags = tags
         )
 


### PR DESCRIPTION
### The problem

We used a commit hash as a release in Sentry events. 

It's hard to understand the health of release because of many tiny releases:

![Screenshot from 2021-04-03 15-41-59](https://user-images.githubusercontent.com/1104540/113482645-4223ef80-94a8-11eb-8890-0b166cea2eaf.png)

Also, I can't resolve an issue and select the next release. Instead of this, I have to suppress the issue until the next release date. It's error-prone.

![Screenshot from 2021-04-03 15-31-31](https://user-images.githubusercontent.com/1104540/113482715-94fda700-94a8-11eb-9659-f9bfe7082862.png)

### Changes

- Store an infra version [inside JARs](https://github.com/avito-tech/avito-android/pull/910#discussion_r606674741)
- Use infra version as release in Sentry events

### The next steps

Do the same for Android libraries and events from instrumentation tests.