### PR TITLE
Package version of Android libraries and use it as a release in Sentry events

### DIFF
--- a/build-logic/android-convention/src/main/kotlin/convention.kotlin-android-library.gradle.kts
+++ b/build-logic/android-convention/src/main/kotlin/convention.kotlin-android-library.gradle.kts
@@ -1,9 +1,14 @@
+import com.android.build.gradle.internal.tasks.ProcessJavaResTask
+import java.util.jar.Attributes
+
 plugins {
     id("com.android.library")
     id("kotlin-android")
     id("convention.kotlin-base")
     id("convention.android-base")
 }
+
+val generatedJavaResDir = project.layout.buildDirectory.file("generated/avito/java_res")
 
 android {
 
@@ -23,4 +28,21 @@ android {
             enabled = false
         }
     }
+
+    sourceSets {
+        getByName("main").resources.srcDir(generatedJavaResDir.get().asFile)
+    }
+}
+
+val generateLibraryJavaResProvider: TaskProvider<WriteProperties> =
+    project.tasks.register<WriteProperties>("generateLibraryJavaRes") {
+        // Don't use MANIFEST.MF to avoid clashing and rewriting in packaging
+        val projectUniqueProperties = "META-INF/com.avito.android.${project.name}.properties"
+        outputFile = File(generatedJavaResDir.get().asFile, projectUniqueProperties)
+
+        property(Attributes.Name.IMPLEMENTATION_VERSION.toString(), project.version.toString())
+    }
+
+project.tasks.withType<ProcessJavaResTask>().configureEach {
+    dependsOn(generateLibraryJavaResProvider)
 }

--- a/build-logic/kotlin-convention/src/main/kotlin/convention.kotlin-jvm.gradle.kts
+++ b/build-logic/kotlin-convention/src/main/kotlin/convention.kotlin-jvm.gradle.kts
@@ -1,4 +1,17 @@
+import java.util.jar.Attributes
+
 plugins {
     id("kotlin")
     id("convention.kotlin-base")
+}
+
+tasks.withType(Jar::class.java).configureEach {
+    manifest {
+        attributes(
+            mapOf(
+                // To access a build version in runtime through class.java.`package`.implementationVersion
+                Attributes.Name.IMPLEMENTATION_VERSION.toString() to project.version
+            )
+        )
+    }
 }

--- a/build-logic/publication/src/main/kotlin/convention.publish-base.gradle.kts
+++ b/build-logic/publication/src/main/kotlin/convention.publish-base.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.jar.Attributes
-
 plugins {
     `maven-publish`
 }
@@ -10,16 +8,6 @@ group = "com.avito.android"
 version = providers.gradleProperty("projectVersion")
     .forUseAtConfigurationTime()
     .get()
-
-tasks.withType<Jar> {
-    manifest {
-        attributes(
-            mapOf(
-                Attributes.Name.IMPLEMENTATION_VERSION.toString() to project.version
-            )
-        )
-    }
-}
 
 publishing.publications.withType<MavenPublication> {
     pom {

--- a/subprojects/android-test/test-inhouse-runner/build.gradle.kts
+++ b/subprojects/android-test/test-inhouse-runner/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
         because("InHouseInstrumentationTestRunner.sentry")
     }
 
+    implementation(project(":common:build-metadata"))
     implementation(project(":common:sentry"))
     implementation(project(":common:elastic-logger"))
     implementation(project(":common:http-client"))

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/TestRunEnvironment.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/TestRunEnvironment.kt
@@ -17,6 +17,7 @@ import com.avito.android.test.report.model.TestMetadata
 import com.avito.android.test.report.transport.ReportDestination
 import com.avito.android.test.report.video.VideoFeatureValue
 import com.avito.report.model.ReportCoordinates
+import com.avito.utils.BuildMetadata
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.io.File
@@ -167,6 +168,8 @@ private fun parseSentryConfig(argumentsProvider: ArgsProvider): SentryConfig {
     val tags = mapOf(
         "API" to Build.VERSION.SDK_INT.toString()
     )
+    val release = BuildMetadata.androidLibVersion("test-inhouse-runner")
+
     return if (dsn.isNullOrBlank()) {
         SentryConfig.Disabled
     } else {
@@ -174,7 +177,7 @@ private fun parseSentryConfig(argumentsProvider: ArgsProvider): SentryConfig {
             dsn = dsn,
             environment = "android-test",
             serverName = "",
-            release = "",
+            release = release,
             tags = tags
         )
     }

--- a/subprojects/common/build-metadata/build.gradle.kts
+++ b/subprojects/common/build-metadata/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("convention.kotlin-jvm")
+    id("convention.publish-kotlin-library")
+}

--- a/subprojects/common/build-metadata/src/main/kotlin/com/avito/utils/BuildMetadata.kt
+++ b/subprojects/common/build-metadata/src/main/kotlin/com/avito/utils/BuildMetadata.kt
@@ -1,0 +1,39 @@
+package com.avito.utils
+
+import java.util.Properties
+import java.util.jar.Attributes
+
+object BuildMetadata {
+
+    /**
+     * Build version of a Kotlin library that contains the class
+     */
+    fun <T : Any> kotlinLibraryVersion(clazz: Class<T>): String {
+        val version: String? = clazz.`package`.implementationVersion
+        val isEmpty = version.isNullOrBlank() || version == "0.0"
+        check(!isEmpty) {
+            "Can't load implementation version for $this. Value: \"$version\". Check manifest options for Jar"
+        }
+        return version!!
+    }
+
+    /**
+     * Build version of an Android library that contains the class
+     *
+     * @moduleName - Gradle project name with the class
+     */
+    fun androidLibVersion(moduleName: String): String {
+        val fileName = "META-INF/com.avito.android.$moduleName.properties"
+        val propertiesStream = requireNotNull(BuildMetadata::class.java.classLoader!!.getResourceAsStream(fileName)) {
+            "Can't find $fileName for $moduleName module. Check generated resources in the library"
+        }
+        val properties = Properties()
+        properties.load(propertiesStream)
+
+        val propertyName = Attributes.Name.IMPLEMENTATION_VERSION.toString()
+
+        return requireNotNull(properties.getProperty(propertyName)) {
+            "Can't find $propertyName in $fileName"
+        }
+    }
+}

--- a/subprojects/common/sentry/src/main/kotlin/com/avito/android/sentry/SentryConfig.kt
+++ b/subprojects/common/sentry/src/main/kotlin/com/avito/android/sentry/SentryConfig.kt
@@ -31,7 +31,7 @@ fun sentryClient(config: SentryConfig): SentryClient {
  *
  * https://github.com/getsentry/sentry-java/issues/543
  */
-private const val DEFAULT_SENTRY_MAX_STRING: Int = 50000
+private const val DEFAULT_SENTRY_MAX_STRING: Int = 50_000
 
 /**
  * Default config for SentryClient

--- a/subprojects/gradle/sentry-config/build.gradle.kts
+++ b/subprojects/gradle/sentry-config/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(project(":common:sentry"))
 
     implementation(gradleApi())
+    implementation(project(":common:build-metadata"))
     implementation(project(":common:okhttp"))
     implementation(project(":common:logger"))
     implementation(project(":gradle:build-environment"))

--- a/subprojects/gradle/sentry-config/src/main/kotlin/com/avito/android/sentry/ProjectExtensions.kt
+++ b/subprojects/gradle/sentry-config/src/main/kotlin/com/avito/android/sentry/ProjectExtensions.kt
@@ -7,6 +7,7 @@ import com.avito.kotlin.dsl.PropertyScope.ROOT_PROJECT
 import com.avito.kotlin.dsl.getBooleanProperty
 import com.avito.kotlin.dsl.getMandatoryStringProperty
 import com.avito.kotlin.dsl.getOptionalStringProperty
+import com.avito.utils.BuildMetadata
 import com.avito.utils.gradle.buildEnvironment
 import io.sentry.SentryClient
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -36,7 +37,7 @@ private fun from(project: Project): SentryConfig {
             tags[buildIdTag] = buildId
         }
 
-        val infraVersion = SentryConfig::class.java.`package`.implementationVersion
+        val infraVersion = BuildMetadata.kotlinLibraryVersion(SentryConfig::class.java)
 
         val config = SentryConfig.Enabled(
             dsn = project.getMandatoryStringProperty("avito.sentry.dsn"),

--- a/subprojects/settings.gradle.kts
+++ b/subprojects/settings.gradle.kts
@@ -65,6 +65,7 @@ include(":gradle:worker")
 include(":gradle:gradle-logger")
 include(":gradle:module-dependencies-graph")
 
+include(":common:build-metadata")
 include(":common:resources")
 include(":common:files")
 include(":common:time")


### PR DESCRIPTION
Continuation of #910 

- Added infra version to Android libraries
- Use infra version as a release in Sentry events from instrumentation tests.

Implementation details:
All java resources are merged implicitly in Android application. We don't forbid different versions for libraries.
So, we generate a unique `META-INF/<project>.properties` java resource file for each Android library.
It looks like a common approach. I see other external libraries with similar files for versions.
