### PR TITLE
MBS-11034 Fix draft release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,22 +204,23 @@ unsafe_clear_local_branches:
 	git branch -r | awk '{print $$1}' | egrep -v -f /dev/fd/0 <(git branch -vv | grep origin) | \
 	awk '{print $$1}' | xargs git branch -D
 
-# precondition:
+# Precondition:
 # - installed CLI: https://cli.github.com/
 # - push $(version) branch
 #
-# post actions:
-# - go to link in output
-# - edit notes
-# - publish release
+# Post actions:
+# - Go to a link in output
+# - Edit notes
+# - Publish the release
 draft_release:
 	$(call check_defined, version)
 	$(call check_defined, prev_version)
+	git fetch --all
 	gh release create $(version) \
 		--draft \
 		--target $(version) \
 		--title $(version) \
-		--notes "$$(git log --pretty=format:%s $(prev_version)..$(version) | cat)"
+		--notes "$$(git log --pretty=format:%s origin/$(prev_version)..origin/$(version) | cat)"
 
 dynamic_properties:
 	$(eval keepFailedTestsFromReport?=)


### PR DESCRIPTION
Switched to origin branches refs.
`<prev release>..<next release>` could be ambiguous for git.

```
> git version
git version 2.25.1
> git fetch --all
> git log --pretty=format:%s 2021.12..2021.13       
fatal: ambiguous argument '2021.12..2021.13': unknown revision or path not in the working tree.
```

The previous release is a tag. 
The next release is a branch. The tag will be created after publishing a release.