### PR TITLE
MBS-11010 Hide registering unexpected incident logic to report impl

### DIFF
--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/InHouseInstrumentationTestRunner.kt
@@ -26,7 +26,6 @@ import com.avito.android.test.report.ReportTestListener
 import com.avito.android.test.report.ReportViewerHttpInterceptor
 import com.avito.android.test.report.ReportViewerWebsocketReporter
 import com.avito.android.test.report.StepDslProvider
-import com.avito.android.test.report.incident.AppCrashException
 import com.avito.android.test.report.listener.TestLifecycleNotifier
 import com.avito.android.test.report.model.TestMetadata
 import com.avito.android.test.report.screenshot.ScreenshotCapturer
@@ -249,7 +248,7 @@ abstract class InHouseInstrumentationTestRunner :
     override fun onException(obj: Any?, e: Throwable): Boolean {
         testRunEnvironment.executeIfRealRun {
             logger.warn("Application crash captured by onException handler inside instrumentation", e)
-            tryToReportUnexpectedIncident(incident = e)
+            reportUnexpectedIncident(incident = e)
         }
 
         return super.onException(obj, e)
@@ -275,15 +274,8 @@ abstract class InHouseInstrumentationTestRunner :
         }
     }
 
-    fun tryToReportUnexpectedIncident(incident: Throwable) {
-        try {
-            if (!report.isWritten) {
-                report.registerIncident(AppCrashException(incident))
-                report.finishTestCase()
-            }
-        } catch (t: Throwable) {
-            logger.critical("Can't register and report unexpected incident", t)
-        }
+    internal fun reportUnexpectedIncident(incident: Throwable) {
+        report.unexpectedFailedTestCase(incident)
     }
 
     /**

--- a/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/ReportUncaughtHandler.kt
+++ b/subprojects/android-test/test-inhouse-runner/src/main/kotlin/com/avito/android/runner/ReportUncaughtHandler.kt
@@ -16,7 +16,7 @@ internal class ReportUncaughtHandler(
             logger.debug("Non critical error caught by ReportUncaughtHandler. ${e.message}")
         } else {
             logger.warn("Application crashed", e)
-            InHouseInstrumentationTestRunner.instance.tryToReportUnexpectedIncident(incident = e)
+            InHouseInstrumentationTestRunner.instance.reportUnexpectedIncident(incident = e)
             globalExceptionHandler?.uncaughtException(t, e)
         }
     }

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/InternalReport.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/InternalReport.kt
@@ -4,18 +4,10 @@ import com.avito.android.test.report.model.StepResult
 import com.avito.android.test.report.model.TestMetadata
 
 interface InternalReport : ReportTestLifecycle<StepResult> {
-
-    val isWritten: Boolean
-
     // delete init
     fun initTestCase(testMetadata: TestMetadata)
 
-    fun registerIncident(
+    fun unexpectedFailedTestCase(
         exception: Throwable
-    )
-
-    fun registerIncident(
-        exception: Throwable,
-        screenshotName: String
     )
 }

--- a/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/incident/AppCrashIncidentPresenter.kt
+++ b/subprojects/android-test/test-report/src/main/kotlin/com/avito/android/test/report/incident/AppCrashIncidentPresenter.kt
@@ -11,4 +11,4 @@ internal class AppCrashIncidentPresenter : IncidentPresenter {
         Result.Success(listOf(IncidentElement(message = "Crash приложения")))
 }
 
-class AppCrashException(cause: Throwable) : Exception(cause)
+internal class AppCrashException(cause: Throwable) : Exception(cause)

--- a/subprojects/android-test/test-report/src/test/kotlin/com/avito/android/test/report/ReportTest.kt
+++ b/subprojects/android-test/test-report/src/test/kotlin/com/avito/android/test/report/ReportTest.kt
@@ -35,7 +35,7 @@ class ReportTest {
 
     @Test
     fun `report incident - step chain`() {
-        report.registerIncident(
+        report.stepFailed(
             StepException(
                 false,
                 "Тапнуть по кнопка",
@@ -55,7 +55,7 @@ class ReportTest {
     }
 
     @Test
-    fun `report incident - resourceManager chain`() {
+    fun `failed test case - resourceManager chain`() {
         val gson = Gson()
         val chain = listOf(
             IncidentElement(
@@ -89,7 +89,7 @@ class ReportTest {
             )
         )
 
-        report.registerIncident(
+        report.failedTestCase(
             exception = ResourceManagerException(
                 message = "Resource manager error: http://host.ru (https://host.ru/some/thing)",
                 cause = null,


### PR DESCRIPTION
client must be clear from report state logic
Changed sematics - now unexpected incident after report was written event is a warning not a critical