### PR TITLE
Detect critical TODOs comments by STOPSHIP tag

### DIFF
--- a/subprojects/detekt.yml
+++ b/subprojects/detekt.yml
@@ -567,8 +567,8 @@ style:
     # https://detekt.github.io/detekt/style.html#forbiddencomment
     # we use todos a lot, maybe there is a better way
     ForbiddenComment:
-        active: false
-        values: [ 'TODO:', 'FIXME:', 'STOPSHIP:' ]
+        active: true
+        values: [ 'STOPSHIP:' ]
         allowedPatterns: ''
     # https://detekt.github.io/detekt/style.html#forbiddenimport
     # todo maybe use it to ban junit 4 in test code


### PR DESCRIPTION
## The problem

Usually, we use TODOs comments as metadata:

```kotlin
// TODO: Do something later [MBS-123]
fun foo()
```

This is the inevitable evil.

But I have another case occasionally:

```kotlin
// TODO: revert this before pushing!!!
fun uglyTemporaryCodeForDebugging()
```

I don't want to merge such temporary changes. It's not convenient to use only standalone commits for this purpose.
Thus, I'm checking code more thoroughly before a code review. This is error-prone.

## Changes

I see a common pattern for this problem - special TODOs.
I've chosen `STOPSHIP` because it's commonly used and we have the same comment in a built-in Android lint check [`StopShip`](http://tools.android.com/tips/lint-checks)

```kotlin
// STOPSHIP: revert
fun uglyTemporaryCodeForDebugging()
```

If you don't need to use it, that's good. You'll never see this comment.