### PR TITLE
MBS-7244 Collect remote cache hit rate metrics

### DIFF
--- a/docs/content/projects/internal/BuildMetrics.md
+++ b/docs/content/projects/internal/BuildMetrics.md
@@ -28,6 +28,12 @@ They will be referred in docs as `<placeholder>`.
 [Http build cache](https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure_remote) errors:
 
 - `<namespace>.build.cache.errors.[load|store].<http status code>`: errors counter
+  
+Remote cache statistics:
+
+- `<namespace>.build.cache.remote.[hit|miss].env.<environment>`: remote cache operations count by environments.
+Shows count of cacheable tasks that were requested from the remote cache.
+This is the same as **Performance** | **Build cache** | **Remote cache** | **Operations** | **Hit\Miss** in build scan.
 
 ### Common build metrics
 

--- a/subprojects/detekt.yml
+++ b/subprojects/detekt.yml
@@ -568,7 +568,7 @@ style:
     # we use todos a lot, maybe there is a better way
     ForbiddenComment:
         active: true
-        values: [ 'STOPSHIP:' ]
+        values: [ 'STOPSHIP' ]
         allowedPatterns: ''
     # https://detekt.github.io/detekt/style.html#forbiddenimport
     # todo maybe use it to ban junit 4 in test code

--- a/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPluginTest.kt
+++ b/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPluginTest.kt
@@ -1,5 +1,6 @@
 package com.avito.android.plugin.build_metrics
 
+import com.avito.android.stats.TimeMetric
 import com.avito.test.gradle.TestProjectGenerator
 import com.avito.test.gradle.TestResult
 import com.avito.test.gradle.gradlew
@@ -51,7 +52,7 @@ internal class BuildMetricsPluginTest {
         result.assertThat()
             .buildSuccessful()
 
-        result.expectMetric("time", "init_configuration.total")
+        result.assertHasMetric<TimeMetric>(".init_configuration.total")
     }
 
     @Test
@@ -61,7 +62,7 @@ internal class BuildMetricsPluginTest {
         result.assertThat()
             .buildSuccessful()
 
-        result.expectMetric("time", "build-time.total")
+        result.assertHasMetric<TimeMetric>(".build-time.total")
     }
 
     @TestFactory
@@ -90,7 +91,7 @@ internal class BuildMetricsPluginTest {
                 result.assertThat()
                     .buildSuccessful()
 
-                result.expectMetric("time", it.metricName)
+                result.assertHasMetric<TimeMetric>(it.metricName)
             }
         }
     }

--- a/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/StatsdMetrics.kt
+++ b/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/StatsdMetrics.kt
@@ -1,22 +1,42 @@
 package com.avito.android.plugin.build_metrics
 
+import com.avito.android.stats.CountMetric
+import com.avito.android.stats.GaugeDoubleMetric
+import com.avito.android.stats.GaugeLongMetric
+import com.avito.android.stats.SeriesName
+import com.avito.android.stats.StatsMetric
+import com.avito.android.stats.TimeMetric
 import com.avito.test.gradle.TestResult
 import com.google.common.truth.Truth.assertWithMessage
 
 private const val loggerPrefix = "[StatsDSender@:] "
 
-internal fun TestResult.expectMetric(type: String, metricName: String) {
+internal inline fun <reified T : StatsMetric> TestResult.assertHasMetric(path: String): T {
+    val type = T::class.java
     val metrics = statsdMetrics()
-    val filtered = filter(metrics, type, metricName)
+    val filtered = metrics
+        .filterIsInstance(type)
+        .filter {
+            it.name.toString().contains(path)
+        }
 
-    assertWithMessage("Expected metric $type $metricName in $metrics")
+    assertWithMessage("Expected metric ${type.simpleName}($path) in $metrics")
         .that(filtered).hasSize(1)
+
+    return filtered.first()
 }
 
-private fun filter(metrics: List<MetricRecord>, type: String, metricName: String): List<MetricRecord> {
-    return metrics
-        .filter { it.type == type }
-        .filter { it.name.endsWith(".$metricName") }
+internal inline fun <reified T : StatsMetric> TestResult.assertNoMetric(path: String) {
+    val type = T::class.java
+    val metrics = statsdMetrics()
+    val filtered = metrics
+        .filterIsInstance(type)
+        .filter {
+            it.name.toString().contains(path)
+        }
+
+    assertWithMessage("Expected no metric ${type.simpleName}($path) in $metrics")
+        .that(filtered).isEmpty()
 }
 
 /**
@@ -24,18 +44,27 @@ private fun filter(metrics: List<MetricRecord>, type: String, metricName: String
  * ... time:apps.mobile.statistic.android.local.user.id.success.init_configuration.total:5821
  */
 // TODO: Intercept on network layer by simulating statsd server
-internal fun TestResult.statsdMetrics(): List<MetricRecord> {
+internal fun TestResult.statsdMetrics(): List<StatsMetric> {
     return output.lines().asSequence()
         .filter { it.contains(loggerPrefix) }
         .map { it.substringAfter(loggerPrefix) }
         .map { it.substringAfter("event: ") }
-        .map { it.substringBeforeLast(':') }
-        .map { line ->
-            val type = line.substringBefore(':')
-            val name = line.substringAfter(':')
-            MetricRecord(type, name)
-        }
+        .map { parseStatsdMetric(it) }
         .toList()
 }
 
-internal data class MetricRecord(val type: String, val name: String)
+private fun parseStatsdMetric(raw: String): StatsMetric {
+    val type = raw.substringBefore(':')
+    val name = raw.substringBeforeLast(':').substringAfter(':')
+    val value = raw.substringAfterLast(':')
+    return when (type) {
+        "count" -> CountMetric(SeriesName.create(name, multipart = true), value.toLong())
+        "time" -> TimeMetric(SeriesName.create(name, multipart = true), value.toLong())
+        "gauge" -> if (value.contains('.')) {
+            GaugeLongMetric(SeriesName.create(name, multipart = true), value.toLong())
+        } else {
+            GaugeDoubleMetric(SeriesName.create(name, multipart = true), value.toDouble())
+        }
+        else -> throw IllegalStateException("Unknown statsd metric: $raw")
+    }
+}

--- a/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/cache/BuildCacheMetricsTest.kt
+++ b/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/cache/BuildCacheMetricsTest.kt
@@ -1,0 +1,167 @@
+package com.avito.android.plugin.build_metrics.cache
+
+import com.avito.android.plugin.build_metrics.assertHasMetric
+import com.avito.android.stats.CountMetric
+import com.avito.test.gradle.TestResult
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import java.io.File
+
+internal class BuildCacheMetricsTest : BuildCacheTestFixture() {
+
+    override fun setupProject(projectDir: File) {
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                id("com.avito.android.build-metrics")
+            }
+            
+            @CacheableTask
+            abstract class CustomTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+
+                @Input
+                var input: Long = 0
+
+                @OutputFile
+                val outputFile = objects.fileProperty()
+
+                @TaskAction
+                fun createFile() {
+                    outputFile.get().asFile.writeText("Output of CacheableTask: " + input)
+                }
+            }
+            
+            tasks.register("cacheMissTask", CustomTask::class.java) {
+                input = System.currentTimeMillis()
+                outputFile.set(file("build/cacheMissTask.txt"))
+            }
+            tasks.register("cacheHitTask", CustomTask::class.java) {
+                outputFile.set(file("build/cacheHitTask.txt"))
+            }
+            tasks.register("nonCacheableTask", CustomTask::class.java) {
+                outputs.cacheIf { false }
+                outputFile.set(file("build/nonCacheableTask.txt"))
+            }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `metrics - local cache - hit`() {
+        val result = warmupAndBuild(
+            ":cacheHitTask",
+            warmupRemote = false,
+            expectedOutcome = TaskOutcome.FROM_CACHE
+        )
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.hit.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.miss.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `metrics - local cache - miss`() {
+        val result = warmupAndBuild(
+            ":cacheMissTask",
+            warmupRemote = false,
+            expectedOutcome = TaskOutcome.SUCCESS
+        )
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.hit.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.miss.env.").also {
+            assertThat(it.delta).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `metrics - local cache - non cacheable`() {
+        val result = warmupAndBuild(
+            ":nonCacheableTask",
+            warmupRemote = false,
+            expectedOutcome = TaskOutcome.SUCCESS
+        )
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.hit.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.miss.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `metrics - remote cache - hit`() {
+        val result = warmupAndBuild(
+            ":cacheHitTask",
+            warmupLocal = false,
+            expectedOutcome = TaskOutcome.FROM_CACHE
+        )
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.hit.env.").also {
+            assertThat(it.delta).isEqualTo(1)
+        }
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.miss.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `metrics - remote cache - miss`() {
+        val result = warmupAndBuild(
+            ":cacheMissTask",
+            warmupLocal = false,
+            expectedOutcome = TaskOutcome.SUCCESS
+        )
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.hit.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.miss.env.").also {
+            assertThat(it.delta).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `metrics - remote cache - non cacheable`() {
+        val result = warmupAndBuild(
+            ":nonCacheableTask",
+            warmupLocal = false,
+            expectedOutcome = TaskOutcome.SUCCESS
+        )
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.hit.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+
+        result.assertHasMetric<CountMetric>(".build.cache.remote.miss.env.").also {
+            assertThat(it.delta).isEqualTo(0)
+        }
+    }
+
+    private fun warmupAndBuild(
+        task: String,
+        warmupLocal: Boolean = true,
+        warmupRemote: Boolean = true,
+        expectedOutcome: TaskOutcome
+    ): TestResult {
+        build(task, useLocalCache = warmupLocal, useRemoteCache = warmupRemote)
+        clean()
+
+        val result = build(task, useLocalCache = true, useRemoteCache = true)
+
+        result.assertThat().taskWithOutcome(task, expectedOutcome)
+
+        return result
+    }
+}

--- a/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/cache/BuildCacheTestFixture.kt
+++ b/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/cache/BuildCacheTestFixture.kt
@@ -1,0 +1,69 @@
+package com.avito.android.plugin.build_metrics.cache
+
+import com.avito.test.gradle.TestResult
+import com.avito.test.gradle.gradlew
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+internal abstract class BuildCacheTestFixture {
+
+    private lateinit var projectDir: File
+
+    @BeforeEach
+    fun setup(@TempDir tempDir: File) {
+        this.projectDir = tempDir
+
+        File(projectDir, "settings.gradle.kts").writeText(
+            buildCacheBlock()
+        )
+        setupProject(projectDir)
+    }
+
+    abstract fun setupProject(projectDir: File)
+
+    private fun buildCacheBlock(): String {
+        return """
+            fun booleanProperty(name: String, defaultValue: Boolean): Boolean {
+                return if (settings.extra.has(name)) {
+                    settings.extra[name]?.toString()?.toBoolean() ?: defaultValue
+                } else {
+                    defaultValue
+                }
+            }
+                
+            buildCache {
+                local {
+                    isEnabled = booleanProperty("localCacheEnabled", false)
+                    directory = file(".gradle/build-cache")
+                }
+                remote<DirectoryBuildCache> {
+                    isEnabled = booleanProperty("remoteCacheEnabled", false)
+                    directory = file(".gradle/remote-build-cache")
+                    isPush = true
+                }
+            }
+            """.trimIndent()
+    }
+
+    protected fun clean() {
+        File(projectDir, "build").deleteRecursively()
+    }
+
+    protected fun build(
+        vararg tasks: String,
+        useLocalCache: Boolean = true,
+        useRemoteCache: Boolean = true,
+    ): TestResult {
+        return gradlew(
+            projectDir,
+            *tasks,
+            "-Pavito.build.metrics.enabled=true",
+            "-Pavito.stats.enabled=false",
+            "-PlocalCacheEnabled=$useLocalCache",
+            "-PremoteCacheEnabled=$useRemoteCache",
+            "--build-cache",
+            "--debug", // to read statsd logs from stdout
+        )
+    }
+}

--- a/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/cache/HttpBuildCacheTestFixture.kt
+++ b/subprojects/gradle/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/cache/HttpBuildCacheTestFixture.kt
@@ -52,7 +52,7 @@ internal abstract class HttpBuildCacheTestFixture {
     }
 
     // Overriding content is not supported yet, only statuses.
-    // Load should return task specific outputs as zip entry in a vendor specific format.
+    // Load should return task specific outputs as zip entry in an internal format (see BuildCacheCommandFactory).
     // See content of a cache entry for details.
     protected fun givenHttpBuildCache(
         loadHttpStatus: Int = 404,

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
@@ -17,9 +17,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.register
 
-/**
- * Inspired by [gradle-metrics-plugin](https://github.com/nebula-plugins/gradle-metrics-plugin)
- */
 public open class BuildMetricsPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/AbstractBuildOperationListener.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/AbstractBuildOperationListener.kt
@@ -7,6 +7,11 @@ import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
 
+/**
+ * Not thread safe, see BuildOperationListener documentation
+ *
+ * Events are hierarchically organized by id <--> parentId relationships
+ */
 internal abstract class AbstractBuildOperationListener : BuildOperationListener {
 
     override fun started(descriptor: BuildOperationDescriptor, event: OperationStartEvent) {

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/BuildOperationExt.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/BuildOperationExt.kt
@@ -1,0 +1,25 @@
+package com.avito.android.plugin.build_metrics.internal
+
+import org.gradle.internal.operations.BuildOperationDescriptor
+import org.gradle.internal.operations.OperationFinishEvent
+
+internal fun BuildOperationDescriptor.dump(): String {
+    val descriptor = this
+    return BuildOperationDescriptor::class.java.simpleName +
+        "(name: ${descriptor.name}" +
+        ", details: ${descriptor.details}" +
+        ", metadata: ${descriptor.metadata}" +
+        ", id: ${descriptor.id}" +
+        ", parentId: ${descriptor.parentId})"
+}
+
+internal fun OperationFinishEvent.dump(): String {
+    val event = this
+    val duration = event.endTime - event.startTime
+
+    return OperationFinishEvent::class.java.simpleName +
+        "(result: ${event.result}" +
+        ", duration: $duration (${event.startTime}:${event.endTime})" +
+        ", failure: ${event.failure}" +
+        ")"
+}

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/cache/BuildCacheEventsConsumer.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/cache/BuildCacheEventsConsumer.kt
@@ -1,0 +1,65 @@
+package com.avito.android.plugin.build_metrics.internal.cache
+
+import com.avito.android.sentry.EnvironmentInfo
+import com.avito.android.stats.CountMetric
+import com.avito.android.stats.SeriesName
+import com.avito.android.stats.StatsDSender
+import org.gradle.api.provider.Provider
+
+internal interface BuildCacheEventsConsumer {
+
+    fun onCacheLoadError(httpStatus: Int?)
+
+    fun onCacheStoreError(httpStatus: Int?)
+
+    fun onBuildFinished(tasksExecutions: List<TaskExecutionResult>)
+}
+
+internal class BuildCacheEventsConsumerImpl(
+    private val statsd: Provider<StatsDSender>,
+    private val environmentInfo: Provider<EnvironmentInfo>
+) : BuildCacheEventsConsumer {
+
+    override fun onCacheLoadError(httpStatus: Int?) {
+        val name = SeriesName
+            .create("build.cache.errors.load", multipart = true)
+            .append(httpStatus?.toString() ?: "unknown")
+
+        statsd.get().send(CountMetric(name))
+    }
+
+    override fun onCacheStoreError(httpStatus: Int?) {
+        val name = SeriesName
+            .create("build.cache.errors.store", multipart = true)
+            .append(httpStatus?.toString() ?: "unknown")
+
+        statsd.get().send(CountMetric(name))
+    }
+
+    override fun onBuildFinished(tasksExecutions: List<TaskExecutionResult>) {
+        trackRemoteCacheStats(tasksExecutions)
+    }
+
+    private fun trackRemoteCacheStats(tasksExecutions: List<TaskExecutionResult>) {
+        val prefix = SeriesName.create("build.cache.remote", multipart = true)
+
+        val remoteHits = tasksExecutions
+            .count { it.cacheResult is TaskCacheResult.Hit.Remote }
+
+        val remoteMisses = tasksExecutions
+            .count { it.cacheResult is TaskCacheResult.Miss && it.cacheResult.remote }
+
+        statsd.get().send(
+            CountMetric(
+                prefix.append("hit", "env", environmentInfo.get().environment.publicName),
+                remoteHits.toLong()
+            )
+        )
+        statsd.get().send(
+            CountMetric(
+                prefix.append("miss", "env", environmentInfo.get().environment.publicName),
+                remoteMisses.toLong()
+            )
+        )
+    }
+}

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/cache/BuildCacheOperationListener.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/cache/BuildCacheOperationListener.kt
@@ -4,83 +4,133 @@ import com.avito.android.gradle.metric.BuildEventsListener
 import com.avito.android.gradle.metric.NoOpBuildEventsListener
 import com.avito.android.plugin.build_metrics.internal.AbstractBuildOperationListener
 import com.avito.android.plugin.build_metrics.internal.buildOperationListenerManager
-import com.avito.android.stats.CountMetric
-import com.avito.android.stats.SeriesName
-import com.avito.android.stats.StatsDSender
+import com.avito.android.plugin.build_metrics.internal.dump
+import com.avito.android.sentry.environmentInfo
 import com.avito.android.stats.statsd
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.provider.Provider
-import org.gradle.caching.http.HttpBuildCache
+import org.gradle.api.internal.tasks.TaskExecutionOutcome
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
 import org.gradle.caching.internal.controller.operations.LoadOperationDetails
 import org.gradle.caching.internal.controller.operations.StoreOperationDetails
+import org.gradle.caching.internal.operations.BuildCacheRemoteLoadBuildOperationType
+import org.gradle.execution.RunRootBuildWorkBuildOperationType
+import org.gradle.internal.operations.BuildOperationCategory
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.OperationFinishEvent
+import org.gradle.internal.operations.OperationIdentifier
+import java.util.concurrent.ConcurrentHashMap
 
 internal class BuildCacheOperationListener(
-    private val statsd: Provider<StatsDSender>,
+    private val eventsConsumer: BuildCacheEventsConsumer
 ) : AbstractBuildOperationListener() {
 
-    private val cacheErrorMetricPrefix = SeriesName.create("build", "cache", "errors")
+    private val remoteLoadsByParentId: MutableMap<OperationIdentifier, BuildCacheRemoteLoadBuildOperationType.Result> =
+        ConcurrentHashMap()
+    private val tasksExecutionsById: MutableMap<OperationIdentifier, TaskExecutionIntermediateResult> =
+        ConcurrentHashMap()
 
     override fun finished(descriptor: BuildOperationDescriptor, event: OperationFinishEvent) {
+        val result = event.result
         val failure = event.failure
 
-        if (failure != null) {
-            if (descriptor.isLoadOperation()) {
-                trackCacheLoadFailure(failure)
+        when {
+            result is BuildCacheRemoteLoadBuildOperationType.Result -> onCacheRemoteLoad(descriptor, result)
+            result is ExecuteTaskBuildOperationType.Result -> onTaskExecuted(descriptor, result)
+            descriptor.isRunTasksOperation() -> onRunTasks()
+            failure != null && descriptor.details is LoadOperationDetails -> onCacheLoadError(failure)
+            failure != null && descriptor.details is StoreOperationDetails -> onCacheStoreError(failure)
+        }
+    }
+
+    private fun onTaskExecuted(descriptor: BuildOperationDescriptor, result: ExecuteTaskBuildOperationType.Result) {
+        val details = descriptor.details as ExecuteTaskBuildOperationDetails
+
+        tasksExecutionsById[descriptor.id!!] = TaskExecutionIntermediateResult(
+            path = details.taskPath,
+            type = details.task.taskIdentity.type,
+            result = result
+        )
+    }
+
+    private fun onCacheRemoteLoad(
+        descriptor: BuildOperationDescriptor,
+        result: BuildCacheRemoteLoadBuildOperationType.Result
+    ) {
+        val parentId = checkNotNull(descriptor.parentId) {
+            "Unexpected state of ${descriptor.dump()}"
+        }
+        remoteLoadsByParentId[parentId] = result
+    }
+
+    private fun onRunTasks() {
+        eventsConsumer.onBuildFinished(
+            collectTasksExecutions()
+        )
+    }
+
+    private fun collectTasksExecutions(): List<TaskExecutionResult> {
+        return tasksExecutionsById
+            .map { (taskId, intermediateResult) ->
+                val cacheResult = determineTaskCacheResult(taskId, intermediateResult.result)
+
+                TaskExecutionResult(
+                    path = intermediateResult.path,
+                    type = intermediateResult.type,
+                    cacheResult = cacheResult,
+                )
             }
-            if (descriptor.isStoreOperation()) {
-                trackCacheStoreFailure(failure)
+    }
+
+    private fun determineTaskCacheResult(
+        taskId: OperationIdentifier,
+        result: ExecuteTaskBuildOperationType.Result
+    ): TaskCacheResult {
+        val isTaskCacheDisabled = result.cachingDisabledReasonCategory != null
+
+        return if (isTaskCacheDisabled) {
+            TaskCacheResult.Disabled
+        } else {
+            val wasRemoteCacheLoad = remoteLoadsByParentId[taskId] != null
+
+            if (result.isFromCache) {
+                if (wasRemoteCacheLoad) TaskCacheResult.Hit.Remote else TaskCacheResult.Hit.Local
+            } else {
+                // TODO: consider disabled local cache
+                TaskCacheResult.Miss(local = true, remote = wasRemoteCacheLoad)
             }
         }
     }
 
-    private fun trackCacheLoadFailure(failure: Throwable) {
-        val status: String = extractLoadFailureStatusCode(failure) ?: "unknown"
-
-        val prefix = cacheErrorMetricPrefix
-            .append("load")
-            .append(status)
-
-        statsd.get().send(
-            CountMetric(prefix)
+    private fun onCacheLoadError(failure: Throwable) {
+        eventsConsumer.onCacheLoadError(
+            extractLoadFailureStatusCode(failure)
         )
     }
 
-    private fun trackCacheStoreFailure(failure: Throwable) {
-        val status: String = extractStoreFailureStatusCode(failure) ?: "unknown"
-
-        val prefix = cacheErrorMetricPrefix
-            .append("store")
-            .append(status)
-
-        statsd.get().send(
-            CountMetric(prefix)
+    private fun onCacheStoreError(failure: Throwable) {
+        eventsConsumer.onCacheStoreError(
+            extractStoreFailureStatusCode(failure)
         )
     }
 
-    private fun BuildOperationDescriptor.isLoadOperation(): Boolean {
-        return details is LoadOperationDetails
-            && name.startsWith("Load entry")
-            && name.contains("remote build cache")
-    }
-
-    private fun BuildOperationDescriptor.isStoreOperation(): Boolean {
-        return details is StoreOperationDetails
-            && name.startsWith("Store entry")
-            && name.contains("remote build cache")
+    private fun BuildOperationDescriptor.isRunTasksOperation(): Boolean {
+        return details is RunRootBuildWorkBuildOperationType.Details
+            && metadata == BuildOperationCategory.RUN_WORK_ROOT_BUILD
     }
 
     /**
      * Sample:
      * Loading entry from 'http://host/cache/abcdef' response status 500: Server Error
      */
-    private fun extractLoadFailureStatusCode(error: Throwable): String? {
+    private fun extractLoadFailureStatusCode(error: Throwable): Int? {
         val message = error.message ?: return null
 
         return if (message.startsWith("Loading entry from")) {
             message.substringAfter(" response status ").substringBefore(':').trim()
+                .toInt()
         } else {
             null
         }
@@ -90,11 +140,12 @@ internal class BuildCacheOperationListener(
      * Sample:
      * Storing entry at 'http://host/cache/abcdef' response status 500: Server Error
      */
-    private fun extractStoreFailureStatusCode(error: Throwable): String? {
+    private fun extractStoreFailureStatusCode(error: Throwable): Int? {
         val message = error.message ?: return null
 
         return if (message.startsWith("Storing entry at")) {
             message.substringAfter(" response status ").substringBefore(':').trim()
+                .toInt()
         } else {
             null
         }
@@ -105,8 +156,13 @@ internal class BuildCacheOperationListener(
         fun register(project: Project): BuildEventsListener {
             if (!canTrackRemoteCache(project)) return NoOpBuildEventsListener()
 
+            val eventsConsumer = BuildCacheEventsConsumerImpl(
+                statsd = project.statsd,
+                environmentInfo = project.environmentInfo()
+            )
+
             val buildOperationListener = BuildCacheOperationListener(
-                statsd = project.statsd
+                eventsConsumer
             )
             project.gradle.buildOperationListenerManager().addListener(buildOperationListener)
 
@@ -117,7 +173,15 @@ internal class BuildCacheOperationListener(
             val remoteBuildCache = (project as ProjectInternal).gradle.settings.buildCache.remote
             return remoteBuildCache != null
                 && remoteBuildCache.isEnabled
-                && remoteBuildCache is HttpBuildCache
         }
     }
 }
+
+private data class TaskExecutionIntermediateResult(
+    val path: String,
+    val type: Class<out Task>,
+    val result: ExecuteTaskBuildOperationType.Result
+)
+
+private val ExecuteTaskBuildOperationType.Result.isFromCache: Boolean
+    get() = skipMessage == TaskExecutionOutcome.FROM_CACHE.message

--- a/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/cache/TaskExecutionResult.kt
+++ b/subprojects/gradle/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/cache/TaskExecutionResult.kt
@@ -1,0 +1,24 @@
+package com.avito.android.plugin.build_metrics.internal.cache
+
+import org.gradle.api.Task
+
+internal class TaskExecutionResult(
+    val path: String,
+    val type: Class<out Task>,
+    val cacheResult: TaskCacheResult,
+)
+
+internal sealed class TaskCacheResult {
+
+    object Disabled : TaskCacheResult()
+
+    class Miss(
+        val local: Boolean,
+        val remote: Boolean
+    ) : TaskCacheResult()
+
+    sealed class Hit : TaskCacheResult() {
+        object Local : Hit()
+        object Remote : Hit()
+    }
+}

--- a/subprojects/gradle/test-project/src/main/kotlin/com/avito/test/gradle/TestResultSubject.kt
+++ b/subprojects/gradle/test-project/src/main/kotlin/com/avito/test/gradle/TestResultSubject.kt
@@ -35,8 +35,14 @@ class TestResultSubject private constructor(
     }
 
     fun taskWithOutcome(taskPath: String, outcome: TaskOutcome): TestResultSubject {
-        check("task $taskPath has outcome ${outcome.name}").that(subject.task(taskPath)?.outcome)
-            .isEquivalentAccordingToCompareTo(outcome)
+        val actualOutcome: TaskOutcome? = subject.task(taskPath)?.outcome
+        if (actualOutcome == null) {
+            check("task $taskPath is executed")
+                .that(actualOutcome as Any?).isNotNull()
+        } else {
+            check("task $taskPath has outcome ${outcome.name}")
+                .that(actualOutcome).isEquivalentAccordingToCompareTo(outcome)
+        }
         return this
     }
 


### PR DESCRIPTION
Collect remote cache hit rate. 
This shows the efficiency of the remote cache for clients.

![Screenshot from 2021-04-27 14-08-18](https://user-images.githubusercontent.com/1104540/116232382-bcbbf400-a762-11eb-9b59-31c5421ff58e.png)

This is only on a high level. There are plenty of other attributes and hypotheses for troubleshooting. 
For now, I don't have enough data to decide what else to collect. Need to see high-level metrics firstly.
Now we have all the raw data and adding other metrics won't be a problem.