### PR TITLE
MBS-11063 Use the original Lint issue severity model

### DIFF
--- a/build-logic/kotlin-convention/src/main/kotlin/convention.kotlin-base.gradle.kts
+++ b/build-logic/kotlin-convention/src/main/kotlin/convention.kotlin-base.gradle.kts
@@ -25,3 +25,18 @@ tasks.withType<KotlinCompile>().configureEach {
         freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
     }
 }
+
+val kotlinVersion: String = checkNotNull(
+    System.getProperty("kotlinVersion")
+)
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlin"
+            && requested.name != "kotlin-stdlib-jre8" // deprecated and not updated anymore. It's replaced by jdk
+            && requested.name != "kotlin-stdlib-jre7"
+        ) {
+            useVersion(kotlinVersion)
+        }
+    }
+}

--- a/libraries/src/main/kotlin/com/avito/android/ExternalLibrariesExtension.kt
+++ b/libraries/src/main/kotlin/com/avito/android/ExternalLibrariesExtension.kt
@@ -35,6 +35,7 @@ abstract class ExternalLibrariesExtension @Inject constructor(private val provid
     val buildToolsVersion = "29.0.3"
 
     val androidGradlePluginVersion = systemProperty("androidGradlePluginVersion").get()
+    val androidLintVersion = systemProperty("androidLintVersion").get()
 
     val kotlinXCli = "org.jetbrains.kotlinx:kotlinx-cli:0.2.1"
     val kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
@@ -80,6 +81,7 @@ abstract class ExternalLibrariesExtension @Inject constructor(private val provid
 
     // https://r8.googlesource.com/r8/ (2.1.x <-> AGP 4.1.x)
     val r8 = "com.android.tools:r8:2.1.80"
+    val androidToolsLintApi = "com.android.tools.lint:lint-api:$androidLintVersion"
     val proguardRetrace = "net.sf.proguard:proguard-retrace:6.2.2"
     val playServicesMaps = "com.google.android.gms:play-services-maps:17.0.0"
     val appcompat = "androidx.appcompat:appcompat:${Versions.androidX}"

--- a/subprojects/gradle.properties
+++ b/subprojects/gradle.properties
@@ -27,6 +27,8 @@ systemProp.dependency.analysis.silent=true
 # System property used instead of Gradle, because Gradle properties are not passed to included builds: https://github.com/gradle/gradle/issues/2534
 systemProp.kotlinVersion=1.4.32
 systemProp.androidGradlePluginVersion=4.1.2
+# lint/tools version = AGP version + 23.0.0
+systemProp.androidLintVersion=27.1.2
 systemProp.detektVersion=1.16.0
 systemProp.nebulaIntegTestVersion=8.0.0
 # mandatory from AGP 3.6

--- a/subprojects/gradle/lint-report/build.gradle.kts
+++ b/subprojects/gradle/lint-report/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     api(project(":gradle:build-verdict-tasks-api"))
 
     implementation(libs.okhttp)
+    implementation(libs.androidToolsLintApi)
 
     implementation(project(":common:okhttp"))
     implementation(project(":common:sentry"))

--- a/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/LintIssue.kt
+++ b/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/LintIssue.kt
@@ -1,14 +1,16 @@
 package com.avito.android.lint.internal.model
 
+import com.android.tools.lint.detector.api.Severity
+
 internal class LintIssue(
     val id: String,
     val summary: String,
     val message: String,
     val path: String,
     val line: Int,
-    val severity: Severity
+    @Suppress("UnstableApiUsage")
+    val severity: Severity?
 ) {
-    enum class Severity { UNKNOWN, WARNING, ERROR, INFORMATION }
 
     /**
      * "lint failed to parse file" type of errors

--- a/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/LintResultsParser.kt
+++ b/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/LintResultsParser.kt
@@ -1,5 +1,6 @@
 package com.avito.android.lint.internal.model
 
+import com.android.tools.lint.detector.api.Severity
 import com.avito.logger.LoggerFactory
 import com.avito.logger.create
 import java.io.File
@@ -32,7 +33,8 @@ internal class LintResultsParser(loggerFactory: LoggerFactory) {
         var id: String = "",
         var summary: String = "",
         var message: String = "",
-        var severity: LintIssue.Severity = LintIssue.Severity.UNKNOWN,
+        @Suppress("UnstableApiUsage")
+        var severity: Severity? = null,
         var path: String = "",
         var line: Int = 0
     )
@@ -64,11 +66,9 @@ internal class LintResultsParser(loggerFactory: LoggerFactory) {
                         issue.id = requireNotNull(startElement.getAttributeByName(QName("id"))?.value)
                         issue.summary = requireNotNull(startElement.getAttributeByName(QName("summary"))?.value)
                         issue.message = startElement.getAttributeByName(QName("message"))?.value ?: "No message"
-                        issue.severity = when (startElement.getAttributeByName(QName("severity"))?.value) {
-                            "Error" -> LintIssue.Severity.ERROR
-                            "Warning" -> LintIssue.Severity.WARNING
-                            "Information" -> LintIssue.Severity.INFORMATION
-                            else -> LintIssue.Severity.UNKNOWN
+                        @Suppress("UnstableApiUsage")
+                        issue.severity = Severity.values().firstOrNull { severity ->
+                            severity.description == startElement.getAttributeByName(QName("severity"))?.value.orEmpty()
                         }
                     }
 

--- a/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/slack/LintSlackReporter.kt
+++ b/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/slack/LintSlackReporter.kt
@@ -1,10 +1,9 @@
 package com.avito.android.lint.internal.slack
 
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.Severity.INFORMATIONAL
+import com.android.tools.lint.detector.api.Severity.WARNING
 import com.avito.android.lint.internal.model.LintIssue
-import com.avito.android.lint.internal.model.LintIssue.Severity.ERROR
-import com.avito.android.lint.internal.model.LintIssue.Severity.INFORMATION
-import com.avito.android.lint.internal.model.LintIssue.Severity.UNKNOWN
-import com.avito.android.lint.internal.model.LintIssue.Severity.WARNING
 import com.avito.android.lint.internal.model.LintReportModel
 import com.avito.logger.LoggerFactory
 import com.avito.logger.create
@@ -151,19 +150,21 @@ internal interface LintSlackReporter {
         }
 
         private fun LintIssue.shouldBeAlerted(): Boolean {
+            @Suppress("UnstableApiUsage")
             return !isFatal && severity in arrayOf(ERROR)
         }
 
         private fun LintIssue.shouldBeMentionedInAlert(): Boolean {
-            return !isFatal && severity in arrayOf(WARNING, INFORMATION)
+            @Suppress("UnstableApiUsage")
+            return !isFatal && severity in arrayOf(WARNING, INFORMATIONAL)
         }
 
         private fun LintIssue.shouldBeReportedAsUnexpectedProblem(): Boolean {
             return isFatal
         }
 
-        private fun LintIssue.shouldBeReportedAsParseError(): Boolean {
-            return severity == UNKNOWN
+        private fun LintIssue?.shouldBeReportedAsParseError(): Boolean {
+            return this == null
         }
     }
 }


### PR DESCRIPTION
We parse an Android lint xml report to find errors and decide what to do.
The model of a report is our own and differs from the original.
I've used the original model from lint API.