### PR TITLE
MBS-11063 Avoid classloader constraint violation for lint through plugin

### DIFF
--- a/subprojects/gradle/lint-report/build.gradle.kts
+++ b/subprojects/gradle/lint-report/build.gradle.kts
@@ -12,7 +12,10 @@ dependencies {
     api(project(":gradle:build-verdict-tasks-api"))
 
     implementation(libs.okhttp)
-    implementation(libs.androidToolsLintApi)
+    compileOnly(libs.androidToolsLintApi) {
+        // Example: https://github.com/gradle/gradle/issues/11914
+        because("To avoid classloader constraint violation with lintClassPath")
+    }
 
     implementation(project(":common:http-client"))
     implementation(project(":common:okhttp"))
@@ -27,6 +30,7 @@ dependencies {
     implementation(project(":gradle:slack"))
     implementation(project(":gradle:statsd-config"))
 
+    testImplementation(libs.androidToolsLintApi)
     testImplementation(project(":common:truth-extensions"))
     testImplementation(project(":gradle:slack-test-fixtures"))
     testImplementation(testFixtures(project(":common:logger")))


### PR DESCRIPTION
```
Execution failed for task ':avito:lintRelease'.
	> Lint infrastructure error
Caused by: java.lang.reflect.InvocationTargetException
...
Caused by: java.lang.LinkageError: loader constraint violation: loader org.gradle.internal.classloader.VisitableURLClassLoader @423f138c wants to load interface com.android.tools.lint.model.LintModelLintOptions. 
A different interface with the same name was previously loaded by com.android.tools.lint.gradle.api.DelegatingClassLoader @42d4471a. (com.android.tools.lint.model.LintModelLintOptions is in unnamed module of loader com.android.tools.lint.gradle.api.DelegatingClassLoader @42d4471a, parent loader 'bootstrap')
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        ...
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at com.android.tools.lint.model.LintModelFactory$Companion.getLintOptions(LintModelFactory.kt:1118)
```

We use lint dependency in a Gradle plugin.
Lint tasks configure a classpath in this way:

```
lintTask.lintClassPath = globalScope.getProject().getConfigurations()
                    .getByName("lintClassPath")
                    
protected void runLint(LintBaseTaskDescriptor descriptor) {
        FileCollection lintClassPath = getLintClassPath();
        if (lintClassPath != null) {
            new ReflectiveLintRunner().runLint(getProject().getGradle(),
                    descriptor, lintClassPath.getFiles());
        }
}
```

Decided to exclude dependency from a plugin and use it from an application module.