### PR TITLE
MBS-11063 Fix lint-report error - missing Severity class

### DIFF
--- a/libraries/src/main/kotlin/com/avito/android/ExternalLibrariesExtension.kt
+++ b/libraries/src/main/kotlin/com/avito/android/ExternalLibrariesExtension.kt
@@ -81,7 +81,6 @@ abstract class ExternalLibrariesExtension @Inject constructor(private val provid
 
     // https://r8.googlesource.com/r8/ (2.1.x <-> AGP 4.1.x)
     val r8 = "com.android.tools:r8:2.1.80"
-    val androidToolsLintApi = "com.android.tools.lint:lint-api:$androidLintVersion"
     val proguardRetrace = "net.sf.proguard:proguard-retrace:6.2.2"
     val playServicesMaps = "com.google.android.gms:play-services-maps:17.0.0"
     val appcompat = "androidx.appcompat:appcompat:${Versions.androidX}"

--- a/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/steps/LintReportTest.kt
+++ b/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/steps/LintReportTest.kt
@@ -1,0 +1,80 @@
+package com.avito.ci.steps
+
+import com.avito.test.gradle.TestProjectGenerator
+import com.avito.test.gradle.TestResult
+import com.avito.test.gradle.gradlew
+import com.avito.test.gradle.module.AndroidAppModule
+import com.avito.test.gradle.plugin.plugins
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+internal class LintReportTest {
+
+    private lateinit var projectDir: File
+
+    @BeforeEach
+    fun setup(@TempDir tempPath: Path) {
+        projectDir = tempPath.toFile()
+    }
+
+    @Test
+    fun `lint check - does not send error report - valid project`() {
+        generateProject()
+
+        val buildResult = runBuild()
+        buildResult.assertThat()
+            .buildSuccessful()
+            .taskWithOutcome(":app:lintRelease", TaskOutcome.SUCCESS)
+            .taskWithOutcome(":app:lintReportToChannel", TaskOutcome.SUCCESS)
+    }
+
+    private fun runBuild(): TestResult {
+        return gradlew(
+            projectDir,
+            "app:release",
+            "-Pci=true",
+            "-PbuildNumber=0",
+            "-PteamcityBuildType=stubBuildType",
+            "-PteamcityUrl=http://stub",
+            "-PteamcityBuildId=0"
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    private fun generateProject() {
+        TestProjectGenerator(
+            modules = listOf(
+                AndroidAppModule(
+                    name = "app",
+                    plugins = plugins {
+                        id("com.avito.android.cd")
+                        id("com.avito.android.lint-report")
+                    },
+                    customScript = """
+                            lintReport {
+                                slackToken.set("stub")
+                                slackWorkspace.set("stub")
+                                slackChannelToReportLintBugs.set(new com.avito.slack.model.SlackChannel("id", "#channel"))
+                            }
+                            builds {
+                                release {
+                                    useImpactAnalysis = false
+                                    lint { 
+                                       slackChannelForAlerts = new com.avito.slack.model.SlackChannel("id", "#channel")
+                                    }
+                                    artifacts {
+                                        file("lintReportHtml", "${projectDir.path}/app/build/reports/lint-results-release.html")
+                                        file("lintReportXml", "${projectDir.path}/app/build/reports/lint-results-release.xml")
+                                    }
+                                }
+                            }
+                        """.trimIndent()
+                )
+            )
+        ).generateIn(projectDir)
+    }
+}

--- a/subprojects/gradle/lint-report/build.gradle.kts
+++ b/subprojects/gradle/lint-report/build.gradle.kts
@@ -12,10 +12,6 @@ dependencies {
     api(project(":gradle:build-verdict-tasks-api"))
 
     implementation(libs.okhttp)
-    compileOnly(libs.androidToolsLintApi) {
-        // Example: https://github.com/gradle/gradle/issues/11914
-        because("To avoid classloader constraint violation with lintClassPath")
-    }
 
     implementation(project(":common:http-client"))
     implementation(project(":common:okhttp"))
@@ -30,7 +26,6 @@ dependencies {
     implementation(project(":gradle:slack"))
     implementation(project(":gradle:statsd-config"))
 
-    testImplementation(libs.androidToolsLintApi)
     testImplementation(project(":common:truth-extensions"))
     testImplementation(project(":gradle:slack-test-fixtures"))
     testImplementation(testFixtures(project(":common:logger")))

--- a/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/LintIssue.kt
+++ b/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/LintIssue.kt
@@ -1,14 +1,11 @@
 package com.avito.android.lint.internal.model
 
-import com.android.tools.lint.detector.api.Severity
-
 internal class LintIssue(
     val id: String,
     val summary: String,
     val message: String,
     val path: String,
     val line: Int,
-    @Suppress("UnstableApiUsage")
     val severity: Severity?
 ) {
 

--- a/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/LintResultsParser.kt
+++ b/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/LintResultsParser.kt
@@ -1,6 +1,5 @@
 package com.avito.android.lint.internal.model
 
-import com.android.tools.lint.detector.api.Severity
 import com.avito.logger.LoggerFactory
 import com.avito.logger.create
 import java.io.File

--- a/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/Severity.kt
+++ b/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/model/Severity.kt
@@ -1,0 +1,14 @@
+package com.avito.android.lint.internal.model
+
+internal enum class Severity(val description: String) {
+
+    FATAL("Fatal"),
+
+    ERROR("Error"),
+
+    WARNING("Warning"),
+
+    INFORMATIONAL("Information"),
+
+    IGNORE("Ignore")
+}

--- a/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/slack/LintSlackReporter.kt
+++ b/subprojects/gradle/lint-report/src/main/kotlin/com/avito/android/lint/internal/slack/LintSlackReporter.kt
@@ -1,10 +1,8 @@
 package com.avito.android.lint.internal.slack
 
-import com.android.tools.lint.detector.api.Severity.ERROR
-import com.android.tools.lint.detector.api.Severity.INFORMATIONAL
-import com.android.tools.lint.detector.api.Severity.WARNING
 import com.avito.android.lint.internal.model.LintIssue
 import com.avito.android.lint.internal.model.LintReportModel
+import com.avito.android.lint.internal.model.Severity
 import com.avito.logger.LoggerFactory
 import com.avito.logger.create
 import com.avito.slack.SlackClient
@@ -151,12 +149,12 @@ internal interface LintSlackReporter {
 
         private fun LintIssue.shouldBeAlerted(): Boolean {
             @Suppress("UnstableApiUsage")
-            return !isFatal && severity in arrayOf(ERROR)
+            return !isFatal && severity in arrayOf(Severity.ERROR)
         }
 
         private fun LintIssue.shouldBeMentionedInAlert(): Boolean {
             @Suppress("UnstableApiUsage")
-            return !isFatal && severity in arrayOf(WARNING, INFORMATIONAL)
+            return !isFatal && severity in arrayOf(Severity.WARNING, Severity.INFORMATIONAL)
         }
 
         private fun LintIssue.shouldBeReportedAsUnexpectedProblem(): Boolean {

--- a/subprojects/gradle/lint-report/src/test/kotlin/com/avito/android/lint/model/LintResultsParserTest.kt
+++ b/subprojects/gradle/lint-report/src/test/kotlin/com/avito/android/lint/model/LintResultsParserTest.kt
@@ -1,8 +1,8 @@
 package com.avito.android.lint.model
 
-import com.android.tools.lint.detector.api.Severity
 import com.avito.android.lint.internal.model.LintReportModel
 import com.avito.android.lint.internal.model.LintResultsParser
+import com.avito.android.lint.internal.model.Severity
 import com.avito.android.lint.internal.model.UnsupportedFormatVersion
 import com.avito.logger.StubLoggerFactory
 import com.avito.truth.isInstanceOf


### PR DESCRIPTION
Fix lint report failure caused by missing class.
We can't use original lint dependencies in Gradle plugins due to a custom classloader in Lint (#989).