### PR TITLE
MBS-11260 Fix redundant recalculations of dependencies in impact analysis

### DIFF
--- a/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/AndroidTestConfiguration.kt
+++ b/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/AndroidTestConfiguration.kt
@@ -8,7 +8,7 @@ import com.avito.impact.configuration.sets.isAndroidTest
 import com.avito.module.configurations.ConfigurationType.AndroidTests
 
 class AndroidTestConfiguration(module: InternalModule) :
-    BaseConfiguration(module, setOf(AndroidTests::class.java)) {
+    BaseConfiguration(module, AndroidTests::class.java) {
 
     override val isModified: Boolean by lazy {
         dependencies.any { it.isModified }

--- a/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/BaseConfiguration.kt
+++ b/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/BaseConfiguration.kt
@@ -18,7 +18,7 @@ import java.io.File
  */
 abstract class BaseConfiguration(
     val module: InternalModule,
-    val types: Set<Class<out ConfigurationType>>
+    val type: Class<out ConfigurationType>
 ) : Equality {
 
     abstract val isModified: Boolean
@@ -26,7 +26,7 @@ abstract class BaseConfiguration(
     protected val changesDetector = module.changesDetector
     val path: String = project.path
 
-    open val hasChangedFiles: Boolean by lazy {
+    val hasChangedFiles: Boolean by lazy {
         changedFiles()
             .map { it.isNotEmpty() }
             .onFailure {
@@ -36,7 +36,7 @@ abstract class BaseConfiguration(
     }
 
     open val dependencies: Set<MainConfiguration> by lazy {
-        module.project.dependenciesOnProjects(types)
+        module.project.dependenciesOnProjects(setOf(type))
             .map {
                 it.dependencyProject
                     .internalModule

--- a/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/BaseConfiguration.kt
+++ b/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/BaseConfiguration.kt
@@ -46,17 +46,31 @@ abstract class BaseConfiguration(
     }
 
     fun allDependencies(includeSelf: Boolean = true): Set<BaseConfiguration> {
-        val dependencies = this.dependencies
-            .flatMap {
-                it.allDependencies(includeSelf = true)
-            }
-            .toSet()
-
+        val dependencies = mutableSetOf<BaseConfiguration>()
+        val visited = mutableSetOf<BaseConfiguration>()
+        this.traverseDependencies(visited) { conf: BaseConfiguration ->
+            dependencies.add(conf)
+        }
         return if (includeSelf) {
             dependencies.plus(this)
         } else {
             dependencies
         }
+    }
+
+    @Suppress("unused") // false-positive for receiver
+    private fun BaseConfiguration.traverseDependencies(
+        visited: MutableSet<BaseConfiguration>,
+        visitor: (BaseConfiguration) -> Unit
+    ) {
+        this.dependencies
+            .forEach { node ->
+                if (!visited.contains(node)) {
+                    visitor(node)
+                    node.traverseDependencies(visited, visitor)
+                    visited.add(node)
+                }
+            }
     }
 
     fun sourceSets(): Set<File> {

--- a/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/LintConfiguration.kt
+++ b/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/LintConfiguration.kt
@@ -6,7 +6,7 @@ package com.avito.impact.configuration
 import com.android.build.gradle.api.AndroidSourceSet
 import com.avito.module.configurations.ConfigurationType.Lint
 
-class LintConfiguration(module: InternalModule) : BaseConfiguration(module, setOf(Lint::class.java)) {
+class LintConfiguration(module: InternalModule) : BaseConfiguration(module, Lint::class.java) {
 
     override val isModified: Boolean by lazy {
         dependencies.any { it.isModified }

--- a/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/MainConfiguration.kt
+++ b/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/MainConfiguration.kt
@@ -12,24 +12,13 @@ import com.avito.module.configurations.ConfigurationType.Main
 
 class MainConfiguration(module: InternalModule) : BaseConfiguration(
     module,
-    setOf(
-        Main::class.java
-    )
+    Main::class.java
 ) {
 
     override val isModified: Boolean by lazy {
         module.fallbackDetector.isFallback is ImpactFallbackDetector.Result.Skip
             || dependencies.any { it.isModified }
             || hasChangedFiles
-    }
-
-    override val hasChangedFiles: Boolean by lazy {
-        changedFiles()
-            .map { it.isNotEmpty() }
-            .onFailure {
-                project.logger.error("Can't find changes", it)
-            }
-            .getOrElse { true }
     }
 
     override val dependencies: Set<MainConfiguration> by lazy {

--- a/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/TestConfiguration.kt
+++ b/subprojects/gradle/impact-shared/src/main/java/com/avito/impact/configuration/TestConfiguration.kt
@@ -7,7 +7,7 @@ import com.android.build.gradle.api.AndroidSourceSet
 import com.avito.impact.configuration.sets.isTest
 import com.avito.module.configurations.ConfigurationType.UnitTests
 
-class TestConfiguration(module: InternalModule) : BaseConfiguration(module, setOf(UnitTests::class.java)) {
+class TestConfiguration(module: InternalModule) : BaseConfiguration(module, UnitTests::class.java) {
 
     override val isModified: Boolean by lazy {
         dependencies.any { it.isModified }


### PR DESCRIPTION
It helps to decrease task graph calculation while configuration. 
On sample local build with enabled impact analysis: from 2m to 15s 