### PR TITLE
MBS-11299 revert dir creation check logic

### DIFF
--- a/subprojects/test-runner/test-report-artifacts/src/main/kotlin/com/avito/report/UniqueDirTestArtifactsProvider.kt
+++ b/subprojects/test-runner/test-report-artifacts/src/main/kotlin/com/avito/report/UniqueDirTestArtifactsProvider.kt
@@ -17,18 +17,8 @@ internal class UniqueDirTestArtifactsProvider(
 
         return Result.tryCatch {
             File(runnerDirectory, testFolderName).apply {
-                val parent = parentFile
-                if (parent != null && !parent.exists()) {
-                    require(parent.mkdirs()) {
-                        "Can't create parent dir for dir $this"
-                    }
-                }
-                require(!exists()) {
-                    "Dir $this already existed"
-                }
-                require(mkdir()) {
-                    "Can't create dir $this"
-                }
+                parentFile?.mkdirs()
+                mkdir()
             }
         }
     }


### PR DESCRIPTION
Causes a problem, because every test execution trying to create a new dir, but only testName and deviceName impacts it's unique name