### PR TITLE
MBS-11263 add experimental flag for fetchLogcatForIncompleteTests

### DIFF
--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/TestsRunnerClient.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/TestsRunnerClient.kt
@@ -97,7 +97,8 @@ class TestsRunnerClient {
                 add(
                     ArtifactsTestListener(
                         lifecycleListener = arguments.listener,
-                        loggerFactory = arguments.loggerFactory
+                        loggerFactory = arguments.loggerFactory,
+                        fetchLogcatForIncompleteTests = arguments.fetchLogcatForIncompleteTests
                     )
                 )
             }

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/args/Arguments.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/args/Arguments.kt
@@ -16,7 +16,8 @@ class Arguments(
     val loggerFactory: LoggerFactory,
     val listener: TestLifecycleListener,
     val reservation: DeviceReservation,
-    val metricsConfig: RunnerMetricsConfig
+    val metricsConfig: RunnerMetricsConfig,
+    val fetchLogcatForIncompleteTests: Boolean,
 ) {
 
     override fun toString(): String {

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/listener/ArtifactsTestListener.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/listener/ArtifactsTestListener.kt
@@ -19,7 +19,8 @@ import kotlin.io.path.div
 
 internal class ArtifactsTestListener(
     private val lifecycleListener: TestLifecycleListener,
-    loggerFactory: LoggerFactory
+    loggerFactory: LoggerFactory,
+    private val fetchLogcatForIncompleteTests: Boolean,
 ) : TestListener {
 
     private val logger = loggerFactory.create<ArtifactsTestListener>()
@@ -67,7 +68,13 @@ internal class ArtifactsTestListener(
             is InfrastructureError ->
                 TestResult.Incomplete(
                     infraError = result,
-                    logcat = device.logcat(LOGCAT_LAST_LINES)
+                    logcat = if (fetchLogcatForIncompleteTests) {
+                        device.logcat(LOGCAT_LAST_LINES)
+                    } else {
+                        Result.Failure(
+                            RuntimeException("fetchLogcatForIncompleteTests is disabled in config")
+                        )
+                    }
                 )
 
             Ignored ->
@@ -76,7 +83,7 @@ internal class ArtifactsTestListener(
                         IllegalStateException("Instrumentation executed Ignored test")
                     ),
                     logcat = Result.Failure(
-                        IllegalStateException("Logcat is not needed for ignored test case")
+                        RuntimeException("Logcat is not needed for ignored test case")
                     )
                 )
         }

--- a/subprojects/test-runner/instrumentation-tests/src/integTest/kotlin/com/avito/instrumentation/executing/TestExecutorIntegrationTest.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/integTest/kotlin/com/avito/instrumentation/executing/TestExecutorIntegrationTest.kt
@@ -93,6 +93,7 @@ internal class TestExecutorIntegrationTest {
         testReporter = TestLifecycleListener.STUB,
         configurationName = configurationName,
         loggerFactory = loggerFactory,
-        metricsConfig = metricsConfig
+        metricsConfig = metricsConfig,
+        fetchLogcatForIncompleteTests = false,
     )
 }

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsPlugin.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsPlugin.kt
@@ -130,6 +130,7 @@ public class InstrumentationTestsPlugin : Plugin<Project> {
                     this.buildId.set(env.build.id.toString())
                     this.buildType.set(env.build.type)
                     this.useInMemoryReport.set(extensionData.experimental.useInMemoryReport)
+                    this.fetchLogcatForIncompleteTests.set(extensionData.experimental.fetchLogcatForIncompleteTests)
                     this.gitBranch.set(gitState.map { it.currentBranch.name })
                     this.gitCommit.set(gitState.map { it.currentBranch.commit })
                     this.testRunnerService.set(testRunnerServiceProvider)

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsTask.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsTask.kt
@@ -84,6 +84,9 @@ public abstract class InstrumentationTestsTask @Inject constructor(
     public val useInMemoryReport: Property<Boolean> = objects.property()
 
     @Input
+    public val fetchLogcatForIncompleteTests: Property<Boolean> = objects.property()
+
+    @Input
     public val suppressFailure: Property<Boolean> = objects.property<Boolean>().convention(false)
 
     @Input
@@ -177,7 +180,8 @@ public abstract class InstrumentationTestsTask @Inject constructor(
             ).mapNotNull { it.orNull?.asFile },
             useInMemoryReport = useInMemoryReport.get(),
             uploadTestArtifacts = uploadAllTestArtifacts.get(),
-            reportViewerConfig = reportViewerConfig
+            reportViewerConfig = reportViewerConfig,
+            fetchLogcatForIncompleteTests = fetchLogcatForIncompleteTests.get()
         )
 
         if (testRunnerService.isPresent) {

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/configuration/ExperimentalExtension.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/configuration/ExperimentalExtension.kt
@@ -11,4 +11,6 @@ public abstract class ExperimentalExtension {
     public abstract val useService: Property<Boolean>
 
     public abstract val useInMemoryReport: Property<Boolean>
+
+    public abstract val fetchLogcatForIncompleteTests: Property<Boolean>
 }

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/configuration/InstrumentationPluginConfiguration.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/configuration/InstrumentationPluginConfiguration.kt
@@ -115,7 +115,8 @@ public object InstrumentationPluginConfiguration {
                 testProguardMapping = testProguardMapping,
                 experimental = Data.Experimental(
                     useService = experimental.useService.getOrElse(false),
-                    useInMemoryReport = experimental.useInMemoryReport.getOrElse(false)
+                    useInMemoryReport = experimental.useInMemoryReport.getOrElse(false),
+                    fetchLogcatForIncompleteTests = experimental.fetchLogcatForIncompleteTests.getOrElse(false)
                 )
             )
         }
@@ -135,7 +136,8 @@ public object InstrumentationPluginConfiguration {
 
             public data class Experimental(
                 val useService: Boolean,
-                val useInMemoryReport: Boolean
+                val useInMemoryReport: Boolean,
+                val fetchLogcatForIncompleteTests: Boolean
             ) : Serializable
 
             public data class ReportViewer(

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/InstrumentationTestsAction.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/InstrumentationTestsAction.kt
@@ -83,7 +83,8 @@ internal class InstrumentationTestsAction(
         val reportViewerConfig: ReportViewerConfig?,
         val proguardMappings: List<File>,
         val useInMemoryReport: Boolean,
-        val uploadTestArtifacts: Boolean
+        val uploadTestArtifacts: Boolean,
+        val fetchLogcatForIncompleteTests: Boolean,
     ) : Serializable {
         companion object
     }

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/executing/TestExecutorFactory.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/executing/TestExecutorFactory.kt
@@ -21,7 +21,8 @@ internal interface TestExecutorFactory {
         metricsConfig: RunnerMetricsConfig,
         outputDir: File,
         projectName: String,
-        tempLogcatDir: File
+        tempLogcatDir: File,
+        fetchLogcatForIncompleteTests: Boolean,
     ): TestExecutor
 
     class Implementation : TestExecutorFactory {
@@ -35,7 +36,8 @@ internal interface TestExecutorFactory {
             metricsConfig: RunnerMetricsConfig,
             outputDir: File,
             projectName: String,
-            tempLogcatDir: File
+            tempLogcatDir: File,
+            fetchLogcatForIncompleteTests: Boolean,
         ): TestExecutor {
             return TestExecutorImpl(
                 devicesProvider = devicesProviderFactory.create(
@@ -51,7 +53,8 @@ internal interface TestExecutorFactory {
                 testReporter = testReporter,
                 configurationName = configuration.name,
                 loggerFactory = loggerFactory,
-                metricsConfig = metricsConfig
+                metricsConfig = metricsConfig,
+                fetchLogcatForIncompleteTests = fetchLogcatForIncompleteTests
             )
         }
     }

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/executing/TestExecutorImpl.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/executing/TestExecutorImpl.kt
@@ -30,7 +30,8 @@ internal class TestExecutorImpl(
     private val testReporter: TestLifecycleListener,
     private val configurationName: String,
     private val loggerFactory: LoggerFactory,
-    private val metricsConfig: RunnerMetricsConfig
+    private val metricsConfig: RunnerMetricsConfig,
+    private val fetchLogcatForIncompleteTests: Boolean,
 ) : TestExecutor {
 
     private val logger = loggerFactory.create<TestExecutor>()
@@ -71,7 +72,8 @@ internal class TestExecutorImpl(
                 loggerFactory = loggerFactory,
                 listener = testReporter,
                 reservation = devicesProvider,
-                metricsConfig = metricsConfig
+                metricsConfig = metricsConfig,
+                fetchLogcatForIncompleteTests = fetchLogcatForIncompleteTests
             )
 
             logger.debug("Arguments: $runnerArguments")

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/scheduling/TestsRunnerImplementation.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/scheduling/TestsRunnerImplementation.kt
@@ -23,7 +23,8 @@ internal class TestsRunnerImplementation(
     private val metricsConfig: RunnerMetricsConfig,
     private val devicesProviderFactory: DevicesProviderFactory,
     private val tempLogcatDir: File,
-    private val projectName: String
+    private val projectName: String,
+    private val fetchLogcatForIncompleteTests: Boolean,
 ) : TestsRunner {
 
     override fun runTests(
@@ -57,7 +58,8 @@ internal class TestsRunnerImplementation(
             metricsConfig = metricsConfig,
             outputDir = outputDir,
             projectName = projectName,
-            tempLogcatDir = tempLogcatDir
+            tempLogcatDir = tempLogcatDir,
+            fetchLogcatForIncompleteTests = fetchLogcatForIncompleteTests
         )
 
         executor.execute(

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/scheduling/TestsSchedulerFactory.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/scheduling/TestsSchedulerFactory.kt
@@ -112,7 +112,8 @@ internal interface TestsSchedulerFactory {
                 metricsConfig = metricsConfig,
                 devicesProviderFactory = devicesProviderFactory,
                 tempLogcatDir = tempDir,
-                projectName = params.projectName
+                projectName = params.projectName,
+                fetchLogcatForIncompleteTests = params.fetchLogcatForIncompleteTests
             )
         }
 

--- a/subprojects/test-runner/instrumentation-tests/src/test/kotlin/com/avito/instrumentation/InstrumentationTestsActionIntegrationTest.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/test/kotlin/com/avito/instrumentation/InstrumentationTestsActionIntegrationTest.kt
@@ -56,7 +56,8 @@ internal class InstrumentationTestsActionIntegrationTest {
             metricsConfig: RunnerMetricsConfig,
             outputDir: File,
             projectName: String,
-            tempLogcatDir: File
+            tempLogcatDir: File,
+            fetchLogcatForIncompleteTests: Boolean,
         ): TestExecutor {
             return testRunner
         }

--- a/subprojects/test-runner/instrumentation-tests/src/testFixtures/kotlin/com/avito/instrumentation/stub/StubInstrumentationTestsActionParams.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/testFixtures/kotlin/com/avito/instrumentation/stub/StubInstrumentationTestsActionParams.kt
@@ -33,7 +33,8 @@ internal fun InstrumentationTestsAction.Params.Companion.createStubInstance(
     fileStorageUrl: String = "https://files",
     statsDConfig: StatsDConfig = StatsDConfig.Disabled,
     useInMemoryReport: Boolean = false,
-    uploadTestArtifacts: Boolean = false
+    uploadTestArtifacts: Boolean = false,
+    fetchLogcatForIncompleteTests: Boolean = false,
 ) = InstrumentationTestsAction.Params(
     mainApk = mainApk,
     testApk = testApk,
@@ -54,5 +55,6 @@ internal fun InstrumentationTestsAction.Params.Companion.createStubInstance(
     proguardMappings = emptyList(),
     useInMemoryReport = useInMemoryReport,
     uploadTestArtifacts = uploadTestArtifacts,
-    reportViewerConfig = null
+    reportViewerConfig = null,
+    fetchLogcatForIncompleteTests = fetchLogcatForIncompleteTests
 )


### PR DESCRIPTION
there were some (maybe unrelated) problems on avito integration
false by default