### PR TITLE
MBS-11385 apply gradle versions plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,9 @@ stage_ui_tests:
 	make publish_to_maven_local
 	./gradlew -p $(project) $(log_level) $(params) :android-test:ui-testing-core-app:instrumentationUi -DinfraVersion=local
 
+# todo remove --no-daemon MBS-11385
 test_runner_instrumentation:
-	./gradlew -p samples $(log_level) $(params) :test-runner:instrumentationUi
+	./gradlew -p samples $(log_level) $(params) :test-runner:instrumentationUi --no-daemon
 
 unit_tests:
 	$(docker_command) ./gradlew -p $(project) $(log_level) $(params) test
@@ -253,3 +254,6 @@ dynamic_properties:
 check_avito_configuration:
 	make publish_to_maven_local
 	cd ../avito-android && ./gradlew tasks -DinfraVersion=local
+
+dependency_updates:
+	$(docker_command) ./gradlew -p $(project) $(log_level) $(params) dependencyUpdates -Drevision=release

--- a/build-logic/dependencies-convention/build.gradle.kts
+++ b/build-logic/dependencies-convention/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    `kotlin-dsl`
+}
+
+group = "com.avito.android.buildlogic"
+
+dependencies {
+    implementation("com.github.ben-manes:gradle-versions-plugin:0.39.0")
+}
+
+kotlinDslPluginOptions {
+    experimentalWarning.set(false)
+}

--- a/build-logic/dependencies-convention/src/main/kotlin/convention.dependency-updates.gradle.kts
+++ b/build-logic/dependencies-convention/src/main/kotlin/convention.dependency-updates.gradle.kts
@@ -1,0 +1,18 @@
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+plugins {
+    id("com.github.ben-manes.versions")
+}
+
+tasks.withType<DependencyUpdatesTask> {
+    rejectVersionIf {
+        isNonStable(candidate.version)
+    }
+}
+
+fun isNonStable(version: String): Boolean {
+    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+    val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+    val isStable = stableKeyword || regex.matches(version)
+    return isStable.not()
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "build-logic"
 include("kotlin-convention")
 include("android-convention")
 include("testing-convention")
+include("dependencies-convention")
 include("publication")
 
 pluginManagement {
@@ -76,6 +77,17 @@ dependencyResolutionManagement {
             }
             filter {
                 includeGroup("org.jetbrains.trove4j")
+            }
+        }
+
+        exclusiveContent {
+            forRepository {
+                maven {
+                    setUrlOrProxy("gradle-plugins", "https://plugins.gradle.org/m2/")
+                }
+            }
+            filter {
+                includeModule("com.github.ben-manes", "gradle-versions-plugin")
             }
         }
     }

--- a/subprojects/build.gradle.kts
+++ b/subprojects/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
     id("com.autonomousapps.dependency-analysis") version "0.73.0"
     id("convention.libraries")
+    id("convention.dependency-updates")
 
     // workaround to load plugin classes once:
     // https://youtrack.jetbrains.com/issue/KT-31643#focus=Comments-27-3510019.0-0

--- a/subprojects/settings.gradle.kts
+++ b/subprojects/settings.gradle.kts
@@ -186,6 +186,7 @@ pluginManagement {
                 includeGroupByRegex("nebula\\..*")
                 includeGroup("io.gitlab.arturbosch.detekt")
                 includeGroup("com.autonomousapps.dependency-analysis")
+                includeGroup("com.github.ben-manes.versions")
             }
         }
     }


### PR DESCRIPTION
add temporary --no-daemon to sample instrumentation

# Check version updates

to get updates call `make dependency_updates`

current output:

```
The following dependencies have later release versions:
 - androidx.annotation:annotation [1.1.0 -> 1.2.0]
     https://developer.android.com/jetpack/androidx/releases/annotation#1.2.0
 - androidx.appcompat:appcompat [1.0.0 -> 1.3.0]
     https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.0
 - androidx.recyclerview:recyclerview [1.1.0 -> 1.2.1]
     https://developer.android.com/jetpack/androidx/releases/recyclerview#1.2.1
 - com.android.tools.build:aapt2 [4.1.2-6503028 -> 4.2.1-7147631]
     http://tools.android.com/
 - com.android.tools.build:gradle [4.1.2 -> 4.2.1]
     http://tools.android.com/
 - com.android.tools.ddms:ddmlib [26.2.0 -> 27.2.1]
     http://tools.android.com/
 - com.android.tools.lint:lint-gradle [27.1.2 -> 27.2.1]
     http://tools.android.com/
 - com.fkorotkov:kubernetes-dsl [2.7.1 -> 2.8.1]
 - com.github.gmazzo:okhttp-mock [1.4.0 -> 1.4.1]
     https://github.com/gmazzo/okhttp-client-mock.git
 - com.github.tschuchortdev:kotlin-compile-testing [1.4.0 -> 1.4.1]
     https://github.com/tschuchortdev/kotlin-compile-testing
 - com.google.android.gms:play-services-maps [17.0.0 -> 17.0.1]
 - com.google.android.material:material [1.0.0 -> 1.3.0]
     https://github.com/material-components/material-components-android
 - com.google.auth:google-auth-library-oauth2-http [0.10.0 -> 0.26.0]
     https://github.com/googleapis/google-auth-library-java
 - com.google.code.gson:gson [2.8.5 -> 2.8.7]
     https://github.com/google/gson
 - com.google.truth:truth [1.0 -> 1.1.3]
     http://github.com/google/truth
 - com.jayway.jsonpath:json-path-assert [2.4.0 -> 2.6.0]
     https://github.com/jayway/JsonPath
 - com.squareup:kotlinpoet [1.7.2 -> 1.8.0]
     https://github.com/square/kotlinpoet
 - com.squareup.okhttp3:logging-interceptor [4.9.0 -> 4.9.1]
     https://square.github.io/okhttp/
 - com.squareup.okhttp3:mockwebserver [4.9.0 -> 4.9.1]
     https://square.github.io/okhttp/
 - com.squareup.okhttp3:okhttp [4.9.0 -> 4.9.1]
     https://square.github.io/okhttp/
 - com.squareup.okio:okio [2.7.0 -> 2.10.0]
     https://github.com/square/okio/
 - commons-io:commons-io [2.7 -> 2.9.0]
     LogcatBuffer.Impl.tailer needs to consider Charset (https://issues.apache.org/jira/browse/IO-354)
     https://commons.apache.org/proper/commons-io/
 - io.fabric8:kubernetes-client [4.9.0 -> 5.4.1]
     http://fabric8.io/
 - io.gitlab.arturbosch.detekt:detekt-formatting [1.16.0 -> 1.17.1]
     https://detekt.github.io/detekt
 - io.gitlab.arturbosch.detekt:io.gitlab.arturbosch.detekt.gradle.plugin [1.16.0 -> 1.17.1]
 - io.kubernetes:client-java [8.0.0 -> 12.0.1]
     https://github.com/kubernetes-client/java
 - io.sentry:sentry [1.7.23 -> 5.0.0]
     https://github.com/getsentry/sentry-java
 - junit:junit [4.13 -> 4.13.2]
     http://junit.org
 - me.weishu:free_reflection [2.2.0 -> 3.0.1]
 - org.apache.commons:commons-lang3 [3.8.1 -> 3.12.0]
     https://commons.apache.org/proper/commons-lang/
 - org.apache.commons:commons-text [1.6 -> 1.9]
     https://commons.apache.org/proper/commons-text
 - org.hamcrest:hamcrest-library [1.3 -> 2.2]
     http://hamcrest.org/JavaHamcrest/
 - org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin [1.4.32 -> 1.5.10]
 - org.jetbrains.kotlinx:kotlinx-cli [0.2.1 -> 0.3.2]
 - org.jetbrains.kotlinx:kotlinx-coroutines-core [1.3.7 -> 1.4.2]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.kotlinx:kotlinx-coroutines-test [1.3.7 -> 1.4.2]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.teamcity:teamcity-rest-client [1.6.2 -> 3.5]
 - org.junit.jupiter:junit-jupiter-api [5.7.1 -> 5.7.2]
     https://junit.org/junit5/
 - org.junit.jupiter:junit-jupiter-engine [5.7.1 -> 5.7.2]
     https://junit.org/junit5/
 - org.junit.platform:junit-platform-launcher [1.6.0 -> 1.7.2]
     https://junit.org/junit5/
 - org.junit.platform:junit-platform-runner [1.6.0 -> 1.7.2]
     https://junit.org/junit5/
 - org.mockito:mockito-junit-jupiter [3.3.3 -> 3.11.0]
     https://github.com/mockito/mockito
 - org.slf4j:slf4j-api [1.7.28 -> 1.7.30]
     http://www.slf4j.org
 - org.smali:dexlib2 [2.3 -> 2.5.2]
     http://smali.org

Failed to determine the latest version for the following dependencies (use --info for details):
 - com.google.apis:google-api-services-androidpublisher
 - org.jetbrains.kotlin:kotlin-stdlib
     1.4.32

Gradle release-candidate updates:
 - Gradle: [6.9 -> 7.0.2 -> 7.1-rc-1]
```