### PR TITLE
MBS-10881 artifactory-app-backup no longer applies maven-publish

### DIFF
--- a/subprojects/gradle/artifactory-app-backup/build.gradle.kts
+++ b/subprojects/gradle/artifactory-app-backup/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(project(":gradle:signer"))
     implementation(project(":gradle:android"))
     implementation(project(":gradle:upload-cd-build-result"))
+    implementation(project(":common:problem"))
 
     testImplementation(project(":gradle:artifactory-app-backup-test-fixtures"))
 

--- a/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/CiStepsPluginTest.kt
+++ b/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/CiStepsPluginTest.kt
@@ -45,6 +45,7 @@ class CiStepsPluginTest {
                         id("com.avito.android.qapps")
                         id("com.avito.android.artifactory-app-backup")
                         id("com.avito.android.cd")
+                        id("maven-publish")
                     },
                     customScript = """
                             import com.avito.cd.BuildVariant

--- a/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/steps/UploadCdBuildResultIntegrationTest.kt
+++ b/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/steps/UploadCdBuildResultIntegrationTest.kt
@@ -76,6 +76,7 @@ class UploadCdBuildResultIntegrationTest {
                 id("com.avito.android.instrumentation-tests")
                 id("com.avito.android.artifactory-app-backup")
                 id("com.avito.android.cd")
+                id("maven-publish")
             },
             customScript = """
                         import com.avito.cd.BuildVariant

--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/UploadToArtifactory.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/UploadToArtifactory.kt
@@ -36,7 +36,7 @@ class UploadToArtifactory(
                 name = "${project.name}-android"
                 type = projectType
                 version = "${defaultConfig.versionName}-${defaultConfig.versionCode}-${project.envArgs.build.number}"
-                artifactsMap.forEach { key, output ->
+                artifactsMap.forEach { (key, output) ->
                     artifact(
                         noOwnerClosureOf {
                             id = key


### PR DESCRIPTION
it should be applied manually

no longer works with gradle 7+ because "Cannot run Project.afterEvaluate(Action) when the project is already evaluated" (from maven publish plugin)