### PR TITLE
MBS-11288 fix inmemory report unexpected LOST cases

### DIFF
--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/FinalizerFactoryImpl.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/FinalizerFactoryImpl.kt
@@ -100,7 +100,7 @@ public class FinalizerFactoryImpl(
             actions = actions,
             verdictFile = params.verdictFile,
             verdictDeterminer = verdictDeterminer,
-            finalizerFileDumper = FinalizerFileDumper(
+            finalizerFileDumper = FinalizerFileDumperImpl(
                 outputDir = params.outputDir,
                 loggerFactory = loggerFactory
             )

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/FinalizerFileDumper.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/FinalizerFileDumper.kt
@@ -1,35 +1,12 @@
 package com.avito.runner.finalizer
 
-import com.avito.logger.LoggerFactory
-import com.avito.logger.create
 import com.avito.report.model.AndroidTest
 import com.avito.report.model.TestStaticData
-import com.google.gson.Gson
-import java.io.File
 
-internal class FinalizerFileDumper(
-    private val outputDir: File,
-    loggerFactory: LoggerFactory
-) {
-
-    private val gson = Gson()
-
-    private val logger = loggerFactory.create<FinalizerFileDumper>()
+internal interface FinalizerFileDumper {
 
     fun dump(
         initialTestSuite: Set<TestStaticData>,
         testResults: Collection<AndroidTest>
-    ) {
-        try {
-            val initialJson = gson.toJson(initialTestSuite)
-            val resultsJson = gson.toJson(testResults)
-
-            val verdictDir = File(outputDir, "verdict").apply { mkdirs() }
-
-            File(verdictDir, "initial.json").writeText(initialJson)
-            File(verdictDir, "results.json").writeText(resultsJson)
-        } catch (e: Throwable) {
-            logger.warn("Can't dump test suite finalize data", e)
-        }
-    }
+    )
 }

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/FinalizerFileDumperImpl.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/FinalizerFileDumperImpl.kt
@@ -1,0 +1,35 @@
+package com.avito.runner.finalizer
+
+import com.avito.logger.LoggerFactory
+import com.avito.logger.create
+import com.avito.report.model.AndroidTest
+import com.avito.report.model.TestStaticData
+import com.google.gson.Gson
+import java.io.File
+
+internal class FinalizerFileDumperImpl(
+    private val outputDir: File,
+    loggerFactory: LoggerFactory
+) : FinalizerFileDumper {
+
+    private val gson = Gson()
+
+    private val logger = loggerFactory.create<FinalizerFileDumper>()
+
+    override fun dump(
+        initialTestSuite: Set<TestStaticData>,
+        testResults: Collection<AndroidTest>
+    ) {
+        try {
+            val initialJson = gson.toJson(initialTestSuite)
+            val resultsJson = gson.toJson(testResults)
+
+            val verdictDir = File(outputDir, "verdict").apply { mkdirs() }
+
+            File(verdictDir, "initial.json").writeText(initialJson)
+            File(verdictDir, "results.json").writeText(resultsJson)
+        } catch (e: Throwable) {
+            logger.warn("Can't dump test suite finalize data", e)
+        }
+    }
+}

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/FinalizerImpl.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/FinalizerImpl.kt
@@ -16,7 +16,7 @@ internal class FinalizerImpl(
 
     override fun finalize(testSchedulerResults: TestSchedulerResult): Finalizer.Result {
 
-        val initialTestSuite: Set<TestStaticData> = testSchedulerResults.testSuite.testsToRun.map { it.test }.toSet()
+        val initialTestSuite: Set<TestStaticData> = testSchedulerResults.testsToRun.toSet()
 
         finalizerFileDumper.dump(
             initialTestSuite = initialTestSuite,
@@ -38,4 +38,6 @@ internal class FinalizerImpl(
                 Finalizer.Result.Failure("Instrumentation task failed. Look at verdict in the file: $verdictFile")
         }
     }
+
+    companion object
 }

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/LegacyFinalizer.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/LegacyFinalizer.kt
@@ -28,7 +28,7 @@ internal class LegacyFinalizer(
 
         val testResults = report.getTests()
             .map { testsFromReport ->
-                val testsToRun = testSchedulerResults.testSuite.testsToRun.map { it.test.name }
+                val testsToRun = testSchedulerResults.testsToRun.map { it.name }
                 testsFromReport.filter { TestName(it.className, it.methodName) in testsToRun }
             }
             .onFailure { throwable ->
@@ -40,7 +40,7 @@ internal class LegacyFinalizer(
 
         val notReportedTests = hasNotReportedTestsDeterminer.determine(
             runResult = testResults,
-            allTests = testSchedulerResults.testSuite.testsToRun.map { it.test }
+            allTests = testSchedulerResults.testsToRun
         )
 
         val testRunResult = TestRunResult(

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/action/WriteTaskVerdictAction.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/action/WriteTaskVerdictAction.kt
@@ -68,4 +68,6 @@ internal class WriteTaskVerdictAction(
             testUrl = reportLinkGenerator.generateTestLink(name),
             title = "$name $device $prefix"
         )
+
+    companion object
 }

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/verdict/HasNotReportedTestsDeterminer.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/verdict/HasNotReportedTestsDeterminer.kt
@@ -8,7 +8,7 @@ internal interface HasNotReportedTestsDeterminer {
 
     fun determine(
         runResult: List<SimpleRunTest>,
-        allTests: List<TestStaticData>
+        allTests: Collection<TestStaticData>
     ): Result
 
     sealed class Result {

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/verdict/LegacyNotReportedTestsDeterminer.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/verdict/LegacyNotReportedTestsDeterminer.kt
@@ -13,7 +13,7 @@ internal class LegacyNotReportedTestsDeterminer(
 
     override fun determine(
         runResult: List<SimpleRunTest>,
-        allTests: List<TestStaticData>
+        allTests: Collection<TestStaticData>
     ): HasNotReportedTestsDeterminer.Result {
         val allReportedTests = runResult.map { TestStaticDataPackage.fromSimpleRunTest(it) }
 

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/verdict/VerdictDeterminerImpl.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/verdict/VerdictDeterminerImpl.kt
@@ -77,22 +77,24 @@ internal class VerdictDeterminerImpl(
     }
 
     private fun getFailedTests(testVerdicts: Collection<AndroidTest>): Set<TestStaticData> {
-        return testVerdicts.filterIsInstance<AndroidTest.Completed>().filter { it.incident != null }.toSet()
+        val completedWithIncident =
+            testVerdicts.filterIsInstance<AndroidTest.Completed>().filter { it.incident != null }
+        val infrastructureError = testVerdicts.filterIsInstance<AndroidTest.Lost>()
+
+        return (completedWithIncident + infrastructureError).toSet()
     }
 
     private fun getLostTests(
         initialTestSuite: Set<TestStaticData>,
         testResults: Collection<AndroidTest>
     ): Set<AndroidTest.Lost> {
-        val lostTests = testResults.filterIsInstance<AndroidTest.Lost>()
-
-        val notReportedTests: List<AndroidTest.Lost> = initialTestSuite.subtract(testResults).map {
+        return initialTestSuite.subtract(testResults).map {
             AndroidTest.Lost.createWithoutInfo(
                 testStaticData = it,
                 currentTimeSec = timeProvider.nowInSeconds()
             )
-        }
-
-        return (lostTests + notReportedTests).toSet()
+        }.toSet()
     }
+
+    companion object
 }

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/model/TestSchedulerResult.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/model/TestSchedulerResult.kt
@@ -1,9 +1,9 @@
 package com.avito.runner.scheduler.runner.model
 
 import com.avito.report.model.AndroidTest
-import com.avito.runner.scheduler.suite.TestSuite
+import com.avito.report.model.TestStaticData
 
 public data class TestSchedulerResult(
-    val testSuite: TestSuite,
+    val testsToRun: Collection<TestStaticData>,
     val testResults: Collection<AndroidTest>
 )

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/scheduler/TestSchedulerImpl.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/scheduler/TestSchedulerImpl.kt
@@ -120,7 +120,7 @@ internal class TestSchedulerImpl(
         }
 
         return TestSchedulerResult(
-            testSuite = testSuite,
+            testsToRun = testSuite.testsToRun.map { it.test },
             testResults = report.getTestResults()
         )
     }

--- a/subprojects/test-runner/client/src/test/kotlin/com/avito/runner/finalizer/FinalizerImplTest.kt
+++ b/subprojects/test-runner/client/src/test/kotlin/com/avito/runner/finalizer/FinalizerImplTest.kt
@@ -1,0 +1,91 @@
+package com.avito.runner.finalizer
+
+import com.avito.report.NoOpReportLinkGenerator
+import com.avito.report.model.AndroidTest
+import com.avito.report.model.Incident
+import com.avito.report.model.TestRuntimeDataPackage
+import com.avito.report.model.TestStaticDataPackage
+import com.avito.report.model.createStubInstance
+import com.avito.runner.finalizer.action.WriteTaskVerdictAction
+import com.avito.runner.scheduler.runner.model.TestSchedulerResult
+import com.avito.truth.isInstanceOf
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+internal class FinalizerImplTest {
+
+    @Test
+    fun `finalized - ok - single completed test`() {
+        val finalizerImpl = FinalizerImpl.createStubInstance()
+
+        val test = TestStaticDataPackage.createStubInstance()
+
+        val testSchedulerResult = TestSchedulerResult(
+            testsToRun = listOf(test),
+            testResults = listOf(AndroidTest.Completed.createStubInstance(testStaticData = test))
+        )
+
+        val result = finalizerImpl.finalize(testSchedulerResult)
+
+        assertThat(result).isInstanceOf<Finalizer.Result.Ok>()
+    }
+
+    @Test
+    fun `finalized - lost - single test to run, no results`(@TempDir output: File) {
+        val verdictFile = File(output, "verdict")
+
+        val finalizerImpl = createFinalizer(verdictFile)
+
+        val test = TestStaticDataPackage.createStubInstance()
+
+        val testSchedulerResult = TestSchedulerResult(
+            testsToRun = listOf(test),
+            testResults = emptyList()
+        )
+
+        val result = finalizerImpl.finalize(testSchedulerResult)
+
+        assertThat(result).isInstanceOf<Finalizer.Result.Failure>()
+        assertThat(verdictFile.readText()).contains("${test.name} ${test.device} NOT REPORTED")
+    }
+
+    @Test
+    fun `finalized - ok - single test failure`(@TempDir output: File) {
+        val verdictFile = File(output, "verdict")
+
+        val finalizerImpl = createFinalizer(verdictFile)
+
+        val test = TestStaticDataPackage.createStubInstance()
+
+        val testSchedulerResult = TestSchedulerResult(
+            testsToRun = listOf(test),
+            testResults = listOf(
+                AndroidTest.Completed.createStubInstance(
+                    test,
+                    testRuntimeData = TestRuntimeDataPackage.createStubInstance(
+                        incident = Incident.createStubInstance()
+                    )
+                )
+            )
+        )
+
+        val result = finalizerImpl.finalize(testSchedulerResult)
+
+        assertThat(result).isInstanceOf<Finalizer.Result.Failure>()
+        assertThat(verdictFile.readText()).contains("${test.name} ${test.device} FAILED")
+    }
+
+    private fun createFinalizer(verdictFile: File): FinalizerImpl {
+        val writeTaskVerdictAction = WriteTaskVerdictAction(
+            verdictDestination = verdictFile,
+            reportLinkGenerator = NoOpReportLinkGenerator()
+        )
+
+        return FinalizerImpl.createStubInstance(
+            actions = listOf(writeTaskVerdictAction),
+            verdictFile = verdictFile
+        )
+    }
+}

--- a/subprojects/test-runner/client/src/test/kotlin/com/avito/runner/finalizer/verdict/VerdictDeterminerImplTest.kt
+++ b/subprojects/test-runner/client/src/test/kotlin/com/avito/runner/finalizer/verdict/VerdictDeterminerImplTest.kt
@@ -209,7 +209,7 @@ internal class VerdictDeterminerImplTest {
     }
 
     @Test
-    fun `verdict - lost - single lost test`() {
+    fun `verdict - failed with unsuppressedFailedTest - single lost(infra error) test`() {
         val verdictDeterminer = createVerdictDeterminer()
 
         val test = TestStaticDataPackage.createStubInstance(
@@ -225,12 +225,12 @@ internal class VerdictDeterminerImplTest {
         )
 
         assertThat<Verdict.Failure>(verdict) {
-            assertThat(notReportedTests).contains(test)
+            assertThat(unsuppressedFailedTests).contains(test)
         }
     }
 
     @Test
-    fun `verdict - failed and unsuppressedFailedTests is empty - lost and failed reported and fails suppressed`() {
+    fun `verdict - failed with unsuppressedFailedTests - lost(infra error) and failed reported and fails suppressed`() {
         val verdictDeterminer = createVerdictDeterminer(suppressFailure = true)
 
         val lostTest = TestStaticDataPackage.createStubInstance(
@@ -243,25 +243,26 @@ internal class VerdictDeterminerImplTest {
             deviceName = DeviceName("DEVICE")
         )
 
+        val results = listOf(
+            createLostTestExecution(testStaticData = lostTest),
+            createFailedTestExecution(testStaticData = failedTest)
+        )
+
         val verdict = verdictDeterminer.determine(
             initialTestSuite = setOf(
                 lostTest,
                 failedTest
             ),
-            testResults = listOf(
-                createLostTestExecution(testStaticData = lostTest),
-                createFailedTestExecution(testStaticData = failedTest)
-            )
+            testResults = results
         )
 
-        assertThat<Verdict.Failure>(verdict) {
-            assertThat(notReportedTests).contains(lostTest)
-            assertThat(unsuppressedFailedTests).isEmpty()
+        assertThat<Verdict.Success.Suppressed>(verdict) {
+            assertThat(failedTests).containsExactlyElementsIn(results)
         }
     }
 
     @Test
-    fun `verdict - failed - lost and failed reported`() {
+    fun `verdict - failed - lost(infra error) and failed reported`() {
         val verdictDeterminer = createVerdictDeterminer(suppressFailure = false)
 
         val lostTest = TestStaticDataPackage.createStubInstance(
@@ -274,20 +275,21 @@ internal class VerdictDeterminerImplTest {
             deviceName = DeviceName("DEVICE")
         )
 
+        val results = listOf(
+            createLostTestExecution(testStaticData = lostTest),
+            createFailedTestExecution(testStaticData = failedTest)
+        )
+
         val verdict = verdictDeterminer.determine(
             initialTestSuite = setOf(
                 lostTest,
                 failedTest
             ),
-            testResults = listOf(
-                createLostTestExecution(testStaticData = lostTest),
-                createFailedTestExecution(testStaticData = failedTest)
-            )
+            testResults = results
         )
 
         assertThat<Verdict.Failure>(verdict) {
-            assertThat(notReportedTests).contains(lostTest)
-            assertThat(unsuppressedFailedTests).contains(failedTest)
+            assertThat(unsuppressedFailedTests).containsExactlyElementsIn(results)
         }
     }
 

--- a/subprojects/test-runner/client/src/testFixtures/kotlin/com/avito/runner/finalizer/StubFinalizerFileDumper.kt
+++ b/subprojects/test-runner/client/src/testFixtures/kotlin/com/avito/runner/finalizer/StubFinalizerFileDumper.kt
@@ -1,0 +1,11 @@
+package com.avito.runner.finalizer
+
+import com.avito.report.model.AndroidTest
+import com.avito.report.model.TestStaticData
+
+internal class StubFinalizerFileDumper : FinalizerFileDumper {
+
+    override fun dump(initialTestSuite: Set<TestStaticData>, testResults: Collection<AndroidTest>) {
+        // do nothing
+    }
+}

--- a/subprojects/test-runner/client/src/testFixtures/kotlin/com/avito/runner/finalizer/StubFinalizerImpl.kt
+++ b/subprojects/test-runner/client/src/testFixtures/kotlin/com/avito/runner/finalizer/StubFinalizerImpl.kt
@@ -1,0 +1,21 @@
+package com.avito.runner.finalizer
+
+import com.avito.runner.finalizer.action.FinalizeAction
+import com.avito.runner.finalizer.verdict.VerdictDeterminer
+import com.avito.runner.finalizer.verdict.VerdictDeterminerImpl
+import com.avito.runner.finalizer.verdict.createStubInstance
+import java.io.File
+
+internal fun FinalizerImpl.Companion.createStubInstance(
+    actions: List<FinalizeAction> = emptyList(),
+    verdictFile: File = File("."),
+    verdictDeterminer: VerdictDeterminer = VerdictDeterminerImpl.createStubInstance(),
+    finalizerFileDumper: FinalizerFileDumper = StubFinalizerFileDumper()
+): FinalizerImpl {
+    return FinalizerImpl(
+        actions = actions,
+        verdictFile = verdictFile,
+        verdictDeterminer = verdictDeterminer,
+        finalizerFileDumper = finalizerFileDumper,
+    )
+}

--- a/subprojects/test-runner/client/src/testFixtures/kotlin/com/avito/runner/finalizer/action/StubWriteTaskVerdictAction.kt
+++ b/subprojects/test-runner/client/src/testFixtures/kotlin/com/avito/runner/finalizer/action/StubWriteTaskVerdictAction.kt
@@ -1,0 +1,15 @@
+package com.avito.runner.finalizer.action
+
+import com.avito.report.NoOpReportLinkGenerator
+import com.avito.report.ReportLinkGenerator
+import java.io.File
+
+internal fun WriteTaskVerdictAction.Companion.createStubInstance(
+    verdictDestination: File,
+    reportLinkGenerator: ReportLinkGenerator = NoOpReportLinkGenerator()
+): WriteTaskVerdictAction {
+    return WriteTaskVerdictAction(
+        verdictDestination = verdictDestination,
+        reportLinkGenerator = reportLinkGenerator
+    )
+}

--- a/subprojects/test-runner/client/src/testFixtures/kotlin/com/avito/runner/finalizer/verdict/StubVerdictDeterminerImpl.kt
+++ b/subprojects/test-runner/client/src/testFixtures/kotlin/com/avito/runner/finalizer/verdict/StubVerdictDeterminerImpl.kt
@@ -1,0 +1,16 @@
+package com.avito.runner.finalizer.verdict
+
+import com.avito.time.StubTimeProvider
+import com.avito.time.TimeProvider
+
+internal fun VerdictDeterminerImpl.Companion.createStubInstance(
+    suppressFlaky: Boolean = false,
+    suppressFailure: Boolean = false,
+    timeProvider: TimeProvider = StubTimeProvider()
+): VerdictDeterminerImpl {
+    return VerdictDeterminerImpl(
+        suppressFlaky = suppressFlaky,
+        suppressFailure = suppressFailure,
+        timeProvider = timeProvider,
+    )
+}


### PR DESCRIPTION
Problem was that AndroidTest.Lost type was treated like actual Lost(not reported) tests, but in fact we treat it like InfrastructureError, and suppressFailures should work for it

added tests for this cases and also more integration tests on new Finalizer