### PR TITLE
MBS-7002 investigate clear-package errors

### DIFF
--- a/subprojects/test-runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
+++ b/subprojects/test-runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/AdbDevice.kt
@@ -235,12 +235,12 @@ data class AdbDevice(
 
     override fun clearPackage(name: String): Result<Unit> = retryAction.retry(
         retriesCount = 10,
-        delaySeconds = 2,
+        delaySeconds = 1,
         action = {
             val result = executeBlockingShellCommand(
                 command = listOf("pm", "clear", name),
                 // was seeing ~20% error rate at 5s
-                timeoutSeconds = 10
+                timeoutSeconds = 20
             )
 
             if (!result.output.contains("success", ignoreCase = true)) {

--- a/subprojects/test-runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceEventsLogger.kt
+++ b/subprojects/test-runner/service/src/main/kotlin/com/avito/runner/service/worker/device/adb/listener/AdbDeviceEventsLogger.kt
@@ -86,7 +86,7 @@ internal class AdbDeviceEventsLogger(private val logger: Logger) : AdbDeviceEven
         throwable: Throwable,
         durationMs: Long
     ) {
-        logger.debug("Attempt $attempt: failed to clear package $name")
+        logger.warn("Attempt $attempt: failed to clear package $name in ${durationMs}ms", throwable)
     }
 
     override fun onClearPackageFailure(


### PR DESCRIPTION
promote clear-package failed attempt to warning in logger
increase timeout

raw command line output visible through exception message

Reason: there is a huge error rate on this command, needs investigation

Retries helps (only 1 real failure in 24h)

![image](https://user-images.githubusercontent.com/1105133/123127433-f18eb380-d452-11eb-8fb9-4709980f4c6d.png)
