### PR TITLE
MBS-11583 fix not reported verdict determiner condition

### DIFF
--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/verdict/Verdict.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/finalizer/verdict/Verdict.kt
@@ -13,6 +13,7 @@ internal sealed class Verdict {
 
         data class Suppressed(
             override val testResults: Collection<AndroidTest>,
+            val notReportedTests: Collection<AndroidTest.Lost>,
             val failedTests: Collection<TestStaticData>,
         ) : Success()
     }

--- a/subprojects/test-runner/client/src/test/kotlin/com/avito/runner/finalizer/action/WriteTaskVerdictActionTest.kt
+++ b/subprojects/test-runner/client/src/test/kotlin/com/avito/runner/finalizer/action/WriteTaskVerdictActionTest.kt
@@ -46,6 +46,7 @@ internal class WriteTaskVerdictActionTest {
                 ),
                 failedTest
             ),
+            notReportedTests = emptyList(),
             failedTests = setOf(failedTest)
         )
         val action = createWriteTaskVerdictAction(tempDir)

--- a/subprojects/test-runner/instrumentation-tests/src/gradleTest/kotlin/com/avito/instrumentation/RunnerInputParamsTest.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/gradleTest/kotlin/com/avito/instrumentation/RunnerInputParamsTest.kt
@@ -104,22 +104,27 @@ internal class RunnerInputParamsTest {
 
         buildResult.assertThat().buildSuccessful()
 
-        val dumpDir = projectDir.toPath() / appModuleName / "build" / "test-runner" / dumpDirName
+        val runId = RunId(
+            prefix = "stub",
+            identifier = commit,
+            buildTypeId = "teamcity-$buildType"
+        ).toReportViewerFormat()
 
-        val runnerInput: RunnerInputParams = RunnerInputDumper(dumpDir.toFile()).readInput()
+        val configurationName = "functional"
+
+        val expectedOutputDir = "${projectDir.canonicalPath}/$appModuleName/" +
+            "outputs/stub.$commit.teamcity-buildType/functional"
+
+        val runnerInput: RunnerInputParams = RunnerInputDumper(File(expectedOutputDir)).readInput()
 
         val expectedPluginInstrumentationParams = mapOf(
-            "configuration" to "functional",
+            "configuration" to configurationName,
             "planSlug" to "AppAndroid",
             "jobSlug" to "FunctionalTests",
             "override" to "overrideInConfiguration",
             "deviceName" to "local",
             "teamcityBuildId" to "0",
-            "runId" to RunId(
-                prefix = "stub",
-                identifier = commit,
-                buildTypeId = "teamcity-$buildType"
-            ).toReportViewerFormat(),
+            "runId" to runId,
             "reportApiUrl" to "http://stub", // from InstrumentationPluginConfiguration
             "reportViewerUrl" to "http://stub",
             "fileStorageUrl" to "http://stub",
@@ -292,10 +297,7 @@ internal class RunnerInputParamsTest {
             },
             Case("output dir") {
                 assertThat(it.outputDir.canonicalPath)
-                    .isEqualTo(
-                        "${projectDir.canonicalPath}/$appModuleName/" +
-                            "outputs/stub.$commit.teamcity-buildType/functional"
-                    )
+                    .isEqualTo(expectedOutputDir)
             },
             Case("verdict file") {
                 assertThat(it.verdictFile.canonicalPath)

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsPlugin.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsPlugin.kt
@@ -160,7 +160,6 @@ public class InstrumentationTestsPlugin : Plugin<Project> {
                         this.gitBranch.set(GitResolver.getGitBranch(project))
                         this.gitCommit.set(GitResolver.getGitCommit(project))
                         this.output.set(outputFolder)
-                        this.dumpDir.set(dumpDir)
 
                         if (reportViewer != null) {
                             this.reportViewerProperty.set(reportViewer)

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsTask.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsTask.kt
@@ -106,9 +106,6 @@ public abstract class InstrumentationTestsTask @Inject constructor(
     public abstract val gradleTestKitRun: Property<Boolean>
 
     @get:Internal
-    public abstract val dumpDir: RegularFileProperty
-
-    @get:Internal
     public abstract val kubernetesCredentials: Property<KubernetesCredentials>
 
     @get:OutputDirectory
@@ -153,6 +150,8 @@ public abstract class InstrumentationTestsTask @Inject constructor(
 
         val experiments = experiments.get()
 
+        val output = output.get().asFile
+
         val testRunParams = RunnerInputParams(
             mainApk = application.orNull?.getApk(),
             testApk = testApplication.get().getApkOrThrow(),
@@ -171,7 +170,7 @@ public abstract class InstrumentationTestsTask @Inject constructor(
                 changedTestsFile = changedTests.asFile.orNull
             ),
             loggerFactory = loggerFactory,
-            outputDir = output.get().asFile,
+            outputDir = output,
             verdictFile = verdictFile.get().asFile,
             fileStorageUrl = getFileStorageUrl(),
             statsDConfig = statsDConfig,
@@ -187,7 +186,7 @@ public abstract class InstrumentationTestsTask @Inject constructor(
 
         val isGradleTestKitRun = gradleTestKitRun.get()
 
-        RunnerInputDumper(dumpDir = dumpDir.get().asFile).dumpInput(
+        RunnerInputDumper(output).dumpInput(
             input = testRunParams,
             isGradleTestKitRun = isGradleTestKitRun
         )


### PR DESCRIPTION
Take a look at case, described in a jira task first..

There were two problems, possible clashing:
 - using kotlin `subtract` on different classes leads to always full first collection (maybe not a case in our production, but was easily reproduced in testcase)
 - not reported test (actual, not our converted Lost's) leads to different logic branch and to unexpected fail even with `suppressedFailures` on
 
added problematic test case, should be ok now


also somehow RunnerArgs dump was not posted in teamcity artifacts; move file inside configuration dir; hope it will now