### PR TITLE
MBS-11609 more debug info for kubernetes

### DIFF
--- a/samples/test-runner/build.gradle.kts
+++ b/samples/test-runner/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     androidTestUtil(libs.testOrchestrator)
 }
 
+val avitoRegistry = getOptionalStringProperty("avito.registry")
+
 instrumentation {
     sentryDsn = getOptionalStringProperty("avito.instrumentaion.sentry.dsn") ?: "http://stub-project@stub-host/0"
 
@@ -87,8 +89,6 @@ instrumentation {
         }
     }
 }
-
-val avitoRegistry = getOptionalStringProperty("avito.registry")
 
 fun emulatorImage(api: Int, label: String): String {
     return if (avitoRegistry != null) {

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/EmulatorsLogsReporter.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/EmulatorsLogsReporter.kt
@@ -1,8 +1,13 @@
 package com.avito.android.runner.devices.internal
 
 import com.avito.runner.service.worker.device.Serial
+import java.io.File
 
 internal interface EmulatorsLogsReporter {
+
     fun reportEmulatorLogs(emulatorName: Serial, log: String)
+
     fun redirectLogcat(emulatorName: Serial, device: Device)
+
+    fun getLogFile(podIp: String): File
 }

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/EmulatorsLogsReporterImpl.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/EmulatorsLogsReporterImpl.kt
@@ -10,10 +10,9 @@ internal class EmulatorsLogsReporterImpl(
 ) : EmulatorsLogsReporter {
 
     override fun reportEmulatorLogs(emulatorName: Serial, log: String) {
-        getFile(
-            dir = File(outputFolder, DEVICES_LOGS),
-            emulatorName = emulatorName.value
-        ).writeText(log)
+        getLogFile(emulatorName.value)
+            .apply { parentFile?.mkdirs() }
+            .writeText(log)
     }
 
     override fun redirectLogcat(emulatorName: Serial, device: Device) {
@@ -26,6 +25,10 @@ internal class EmulatorsLogsReporterImpl(
             file = logcatFile,
             tags = logcatTags
         )
+    }
+
+    override fun getLogFile(podIp: String): File {
+        return File(File(outputFolder, DEVICES_LOGS), "$podIp.txt")
     }
 
     private fun getFile(

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubeContainer.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubeContainer.kt
@@ -1,0 +1,84 @@
+package com.avito.android.runner.devices.internal.kubernetes
+
+import io.fabric8.kubernetes.api.model.ContainerStateWaiting
+import io.fabric8.kubernetes.api.model.ContainerStatus
+
+internal class KubeContainer(private val containerStatus: ContainerStatus?) {
+
+    val phase: ContainerPhase
+        get() {
+            val state = containerStatus?.state
+            val running = state?.running
+            val waiting = state?.waiting
+            val terminated = state?.terminated
+
+            return when {
+                waiting != null -> ContainerPhase.Waiting(waiting.describe())
+                running != null -> ContainerPhase.Running
+                terminated != null -> ContainerPhase.Terminated
+                else -> ContainerPhase.Unknown
+            }
+        }
+
+    private fun ContainerStateWaiting.describe(): String {
+        return if (!message.isNullOrBlank()) {
+            message
+        } else {
+            "Waiting"
+        }
+    }
+
+    /**
+     * https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states
+     */
+    sealed class ContainerPhase {
+
+        /**
+         * If a container is not in either the Running or Terminated state, it is Waiting.
+         * A container in the Waiting state is still running the operations it requires in order to complete start up:
+         * for example, pulling the container image from a container image registry, or applying Secret data.
+         * When you use kubectl to query a Pod with a container that is Waiting,
+         * you also see a Reason field to summarize why the container is in that state
+         */
+        data class Waiting(val message: String) : ContainerPhase() {
+
+            fun hasProblemsGettingImage(): Boolean {
+                return hasInvalidImageRef() || cantAccessImage()
+            }
+
+            private fun hasInvalidImageRef(): Boolean {
+                return message.contains("couldn't parse image reference")
+            }
+
+            private fun cantAccessImage(): Boolean {
+                return message.contains("pull access denied for")
+            }
+        }
+
+        /**
+         * The Running status indicates that a container is executing without issues.
+         * If there was a postStart hook configured, it has already executed and finished.
+         * When you use kubectl to query a Pod with a container that is Running,
+         * you also see information about when the container entered the Running state
+         */
+        object Running : ContainerPhase() {
+            override fun toString(): String = "Running"
+        }
+
+        /**
+         * A container in the Terminated state began execution and then either ran to completion or failed for some reason.
+         * When you use kubectl to query a Pod with a container that is Terminated,
+         * you see a reason, an exit code, and the start and finish time for that container's period of execution.
+         */
+        object Terminated : ContainerPhase() {
+            override fun toString(): String = "Terminated"
+        }
+
+        /**
+         * Our synthetic status to handle errors
+         */
+        object Unknown : ContainerPhase() {
+            override fun toString(): String = "Unknown"
+        }
+    }
+}

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubePod.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubePod.kt
@@ -1,0 +1,113 @@
+package com.avito.android.runner.devices.internal.kubernetes
+
+import io.fabric8.kubernetes.api.model.ContainerStatus
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.PodStatus
+
+/**
+ * Wrapper to deal with nullability and abstract from fabric8io API changes
+ */
+internal class KubePod(private val pod: Pod) {
+
+    private val podStatus: PodStatus?
+        get() = pod.status
+
+    private val containerStatus: ContainerStatus?
+        get() = podStatus?.containerStatuses?.firstOrNull()
+
+    private val node: String?
+        get() = pod.spec?.nodeName
+
+    val name: String
+        get() = pod.metadata.name
+
+    val ip: String?
+        get() = podStatus?.podIP
+
+    val phase: PodPhase
+        get() {
+            val status = podStatus
+            return if (status == null) {
+                PodPhase.Unknown
+            } else {
+                when (status.phase) {
+                    "Running" -> PodPhase.Running
+                    "Pending" -> PodPhase.Pending(status.describe())
+                    "Failed" -> PodPhase.Failed(status.describe())
+                    "Succeeded" -> PodPhase.Succeeded
+                    else -> PodPhase.Unknown
+                }
+            }
+        }
+
+    /**
+     * We have one emulator container per pod
+     */
+    val container: KubeContainer
+        get() = KubeContainer(containerStatus)
+
+    override fun toString(): String {
+        return "Pod $name [node=$node; pod=$phase; container=${container.phase}]"
+    }
+
+    private fun PodStatus.describe(): String {
+        return if (!message.isNullOrBlank()) {
+            message
+        } else {
+            val lastConditionMessage = conditions.sortedByDescending { it.lastTransitionTime }
+                .mapNotNull { it.message }
+                .firstOrNull()
+
+            if (!lastConditionMessage.isNullOrBlank()) {
+                lastConditionMessage
+            } else {
+                "Unknown"
+            }
+        }
+    }
+
+    /**
+     * https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+     */
+    sealed class PodPhase {
+
+        /**
+         * The Pod has been bound to a node, and all of the containers have been created.
+         * At least one container is still running, or is in the process of starting or restarting.
+         */
+        object Running : PodPhase() {
+            override fun toString(): String = "Running"
+        }
+
+        /**
+         * The Pod has been accepted by the Kubernetes cluster,
+         * but one or more of the containers has not been set up and made ready to run.
+         * This includes time a Pod spends waiting to be scheduled
+         * as well as the time spent downloading container images over the network.
+         */
+        data class Pending(val message: String) : PodPhase()
+
+        /**
+         * All containers in the Pod have terminated, and at least one container has terminated in failure.
+         * That is, the container either exited with non-zero status or was terminated by the system.
+         */
+        data class Failed(val message: String) : PodPhase()
+
+        /**
+         * All containers in the Pod have terminated in success, and will not be restarted.
+         */
+        object Succeeded : PodPhase() {
+            override fun toString(): String = "Succeeded"
+        }
+
+        /**
+         * For some reason the state of the Pod could not be obtained.
+         * This phase typically occurs due to an error in communicating with the node where the Pod should be running.
+         */
+        object Unknown : PodPhase() {
+            override fun toString(): String = "Unknown"
+        }
+    }
+
+    companion object
+}

--- a/subprojects/test-runner/device-provider/impl/src/test/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClientTest.kt
+++ b/subprojects/test-runner/device-provider/impl/src/test/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClientTest.kt
@@ -86,7 +86,7 @@ internal class KubernetesReservationClientTest {
             ),
         )
         kubernetesApi.createDeployment = { results.poll().invoke() }
-        kubernetesApi.getPods = { Result.Success(listOf(StubPod())) }
+        kubernetesApi.getPods = { Result.Success(listOf(KubePod.createStubInstance())) }
         val exception = assertThrows<RuntimeException>(message = message) {
             runBlocking {
                 client.claim(
@@ -121,7 +121,7 @@ internal class KubernetesReservationClientTest {
         val client = client()
         val results = LinkedList(
             listOf(
-                Result.Success(listOf(StubPod())),
+                Result.Success(listOf(KubePod.createStubInstance())),
                 Result.Failure(RuntimeException())
             ),
         )
@@ -139,7 +139,7 @@ internal class KubernetesReservationClientTest {
     fun `devices channel cancel - success`() {
         val client = client(dispatcher = Dispatchers.Default)
         kubernetesApi.getPods = {
-            Result.Success(listOf(StubPod()))
+            Result.Success(listOf(KubePod.createStubInstance()))
         }
         runBlocking {
             val result = client.claim(listOf(ReservationData.stub()))
@@ -153,7 +153,7 @@ internal class KubernetesReservationClientTest {
     fun `claim then release - success`() {
         val client = client(dispatcher = Dispatchers.Default)
         kubernetesApi.getPods = {
-            Result.Success(listOf(StubPod()))
+            Result.Success(listOf(KubePod.createStubInstance()))
         }
         runBlocking {
             client.claim(listOf(ReservationData.stub()))
@@ -169,7 +169,7 @@ internal class KubernetesReservationClientTest {
                 it.waitForBoot = { Result.Failure(RuntimeException("Wait for boot failed")) }
             }
         }
-        kubernetesApi.getPods = { Result.Success(listOf(StubPod())) }
+        kubernetesApi.getPods = { Result.Success(listOf(KubePod.createStubInstance())) }
         val expectedMessage = "Can't delete pod"
         kubernetesApi.deletePod = {
             throw RuntimeException(expectedMessage)
@@ -189,8 +189,8 @@ internal class KubernetesReservationClientTest {
         val client = client()
         val results = LinkedList(
             listOf(
-                Result.Success(listOf(StubPod(name = "stub-1", ip = null))),
-                Result.Success(listOf(StubPod(name = "stub-2"))),
+                Result.Success(listOf(KubePod.createStubInstance(name = "stub-1", ip = null))),
+                Result.Success(listOf(KubePod.createStubInstance(name = "stub-2"))),
             ),
         )
 

--- a/subprojects/test-runner/device-provider/impl/src/testFixtures/kotlin/com/avito/android/runner/devices/internal/StubEmulatorsLogsReporter.kt
+++ b/subprojects/test-runner/device-provider/impl/src/testFixtures/kotlin/com/avito/android/runner/devices/internal/StubEmulatorsLogsReporter.kt
@@ -1,6 +1,7 @@
 package com.avito.android.runner.devices.internal
 
 import com.avito.runner.service.worker.device.Serial
+import java.io.File
 
 internal object StubEmulatorsLogsReporter : EmulatorsLogsReporter {
 
@@ -10,5 +11,9 @@ internal object StubEmulatorsLogsReporter : EmulatorsLogsReporter {
 
     override fun redirectLogcat(emulatorName: Serial, device: Device) {
         // empty
+    }
+
+    override fun getLogFile(podIp: String): File {
+        return File.createTempFile("stub-log-$podIp", "txt")
     }
 }

--- a/subprojects/test-runner/device-provider/impl/src/testFixtures/kotlin/com/avito/android/runner/devices/internal/kubernetes/FakeKubernetesApi.kt
+++ b/subprojects/test-runner/device-provider/impl/src/testFixtures/kotlin/com/avito/android/runner/devices/internal/kubernetes/FakeKubernetesApi.kt
@@ -9,7 +9,7 @@ internal class FakeKubernetesApi(
 ) : KubernetesApi {
 
     var createDeployment: (Deployment) -> Unit = {}
-    var getPods: (String) -> Result<List<Pod>> = { Result.Success(emptyList()) }
+    var getPods: (String) -> Result<List<KubePod>> = { Result.Success(emptyList()) }
     var deletePod: (String) -> Boolean = { true }
 
     override suspend fun deletePod(podName: String): Boolean {
@@ -36,7 +36,7 @@ internal class FakeKubernetesApi(
         createDeployment.invoke(deployment)
     }
 
-    override suspend fun getPods(deploymentName: String): Result<List<Pod>> {
+    override suspend fun getPods(deploymentName: String): Result<List<KubePod>> {
         return getPods.invoke(deploymentName)
     }
 }

--- a/subprojects/test-runner/device-provider/impl/src/testFixtures/kotlin/com/avito/android/runner/devices/internal/kubernetes/StubPod.kt
+++ b/subprojects/test-runner/device-provider/impl/src/testFixtures/kotlin/com/avito/android/runner/devices/internal/kubernetes/StubPod.kt
@@ -4,16 +4,18 @@ import com.fkorotkov.kubernetes.metadata
 import com.fkorotkov.kubernetes.status
 import io.fabric8.kubernetes.api.model.Pod
 
-internal fun StubPod(
+internal fun KubePod.Companion.createStubInstance(
     name: String = "stub-pod-name",
-    phase: String = KubernetesApi.POD_STATUS_RUNNING,
+    phase: String = "Running",
     ip: String? = "stub-pod-ip"
-): Pod = Pod().apply {
-    metadata {
-        this.name = name
+): KubePod = KubePod(
+    pod = Pod().apply {
+        metadata {
+            this.name = name
+        }
+        status {
+            this.phase = phase
+            podIP = ip
+        }
     }
-    status {
-        this.phase = phase
-        podIP = ip
-    }
-}
+)


### PR DESCRIPTION
KubeContainer and KubePod abstraction layer from fabric8io client
more info about waiting/pending statuses,
point on device log on disconnects

Examples:

## Not yet assigned to node

```
Getting pods for deployment: android-emulator-28efea9e-6891-4915-ac44-0ae34cd6ee80:
----------------
Pod android-emulator-28efea9e-6891-4915-ac44-0ae34cd6ee80-6ff9vmqww [node=null; pod=Pending(message=Unknown); container=Unknown]
------- Summary: running: 0; pending: 1; other 0  ---------
```

## Basic running state

```
Getting pods for deployment: android-emulator-2cb82e1a-fb8b-4211-a1d4-f7798dee71fa:
----------------
Pod android-emulator-28efea9e-6891-4915-ac44-0ae34cd6ee80-6ff9vmqww [node=avi-teamcity04; pod=Running; container=Running]
------- Summary: running: 1; pending: 0; other 0  ---------
```

## No nodes are available

```
Getting pods for deployment: android-emulator-985173cb-d7ce-4878-99dc-f55e513f33ec:
----------------
Pod android-emulator-985173cb-d7ce-4878-99dc-f55e513f33ec-b8d5qcpw5 [node=null; pod=Pending(message=No nodes are available that match all of the predicates: Insufficient cpu (9), Insufficient memory (1), Insufficient pods (16), MatchNodeSelector (139), NodeUnschedulable (6), PodToleratesNodeTaints (136).); container=Unknown]
------- Summary: running: 0; pending: 1; other 0  ---------

```

## Emulator failed to boot
```
Pod android-emulator-28efea9e-6891-4915-ac44-0ae34cd6ee80-6ff9vmqww can't load device. Disconnect and delete.
Check device logs in artifacts: /home/dsvoronin/Work/avito-android-github/samples/test-runner/build/test-runner/a0dedae2d95a769a968cc8773dcf86a6ca227f3f.local-dsvoronin/ui/devices/10.21.218.147.txt
```

and specified file contains:
```
error: kvm run failed Bad address
RAX=ffff97317fc00000 RBX=0000000000011000 RCX=000000000000001f RDX=0000000000000003
RSI=ffffffffafac5722 RDI=ffffffffafa98365 RBP=ffffa45bc34e7c30 RSP=ffffa45bc34e7c28
R8 =0000000000000004 R9 =000000003149ab74 R10=0000000000000000 R11=0000000000000000
R12=ffffffffafc18020 R13=0000000000000000 R14=ffff97317fc0f150 R15=ffffa45bc34e7f58
RIP=ffffffffaea095be RFL=00010006 [-----P-] CPL=0 II=0 A20=1 SMM=0 HLT=0
```