### PR TITLE
MBS-11678 Add tests for Device.rotate() with multiple windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ local.properties
 # output of HeapDumpOnOutOfMemoryError
 *.hprof
 *.log
-# hugo generated files
-public/
 .DS_Store
 outputs/
 gh-pages-generated/
@@ -14,6 +12,8 @@ gh-pages-generated/
 *.iml
 .idea/*
 !.idea/dictionaries/
+# Layout inspector captures
+captures/
 # gradle-profiler
 gradle-user-home
 profile-out*

--- a/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/RotateOrientationTest.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/RotateOrientationTest.kt
@@ -1,0 +1,51 @@
+package com.avito.android.ui.test
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.avito.android.test.Device
+import com.avito.android.test.app.core.screenRule
+import com.avito.android.ui.RotateOrientationActivity
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class RotateOrientationTest {
+
+    @get:Rule
+    val rule = screenRule<RotateOrientationActivity>()
+
+    @Test
+    fun rotate__changes_orientation() {
+        rule.launchActivity(null)
+
+        verifyRotationBehaviour()
+    }
+
+    @Test
+    fun rotate__changes_orientation__with_dialog() {
+        rule.launchActivity(
+            RotateOrientationActivity.intent(openDialog = true)
+        )
+        verifyRotationBehaviour()
+    }
+
+    @Test
+    fun rotate__changes_orientation__with_popup_window() {
+        rule.launchActivity(
+            RotateOrientationActivity.intent(openPopup = true)
+        )
+        verifyRotationBehaviour()
+    }
+
+    private fun verifyRotationBehaviour() {
+        val initialOrientation = orientation()
+
+        Device.rotate()
+
+        val newOrientation = orientation()
+
+        assertThat(initialOrientation).isNotEqualTo(newOrientation)
+    }
+
+    private fun orientation(): Int =
+        InstrumentationRegistry.getInstrumentation().targetContext.resources.configuration.orientation
+}

--- a/subprojects/android-test/ui-testing-core-app/src/main/AndroidManifest.xml
+++ b/subprojects/android-test/ui-testing-core-app/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.avito.android.ui">
@@ -7,8 +8,9 @@
         android:icon="@mipmap/ic_launcher"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"
         tools:ignore="GoogleAppIndexingWarning">
-
-        <activity android:name=".VisibilityActivity">
+        <activity
+            android:name=".VisibilityActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -40,5 +42,6 @@
         <activity android:name=".RecyclerDescendantLevelsActivity" />
         <activity android:name=".ToastActivity" />
         <activity android:name=".OverlapActivity" />
+        <activity android:name=".RotateOrientationActivity" />
     </application>
 </manifest>

--- a/subprojects/android-test/ui-testing-core-app/src/main/kotlin/com/avito/android/ui/RotateOrientationActivity.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/main/kotlin/com/avito/android/ui/RotateOrientationActivity.kt
@@ -1,0 +1,90 @@
+package com.avito.android.ui
+
+import android.annotation.SuppressLint
+import android.content.DialogInterface
+import android.content.Intent
+import android.content.res.Configuration
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.PopupWindow
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+
+class RotateOrientationActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_rotate)
+
+        setupOrientationLabel()
+        setupDialog()
+        setupPopup()
+    }
+
+    private fun setupOrientationLabel() {
+        val orientation = when (resources.configuration.orientation) {
+            Configuration.ORIENTATION_UNDEFINED -> "UNDEFINED"
+            Configuration.ORIENTATION_LANDSCAPE -> "LANDSCAPE"
+            Configuration.ORIENTATION_PORTRAIT -> "PORTRAIT"
+            Configuration.ORIENTATION_SQUARE -> "SQUARE"
+            else -> "UNKNOWN"
+        }
+        findViewById<TextView>(R.id.orientation_label).text = orientation
+    }
+
+    @SuppressLint("SetTextI18n")
+    private fun setupDialog() {
+        if (intent.getBooleanExtra(EXTRA_OPEN_DIALOG, false)) {
+            AlertDialog.Builder(this)
+                .setMessage("Alert dialog")
+                .setNegativeButton("Cancel") { dialog: DialogInterface?, _: Int ->
+                    dialog?.cancel()
+                }
+                .setPositiveButton("Ok") { dialog: DialogInterface?, _: Int ->
+                    dialog?.cancel()
+                }
+                .show()
+        }
+    }
+
+    @SuppressLint("InflateParams", "SetTextI18n")
+    private fun setupPopup() {
+        if (intent.getBooleanExtra(EXTRA_OPEN_POPUP, false)) {
+            val content = findViewById<View>(R.id.content)
+
+            val view = LayoutInflater.from(this).inflate(R.layout.popup_window, null)
+
+            val popup = PopupWindow(
+                view,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+            popup.setBackgroundDrawable(ColorDrawable(Color.GREEN))
+            view.findViewById<TextView>(R.id.title).text = "Popup Window content"
+
+            content.post {
+                popup.showAtLocation(content, Gravity.CENTER, 0, 0)
+            }
+        }
+    }
+
+    companion object {
+
+        private const val EXTRA_OPEN_DIALOG = "extra_open_dialog"
+        private const val EXTRA_OPEN_POPUP = "extra_open_popup"
+
+        fun intent(
+            openDialog: Boolean = false,
+            openPopup: Boolean = false,
+        ): (Intent) -> Intent = {
+            it.putExtra(EXTRA_OPEN_DIALOG, openDialog)
+            it.putExtra(EXTRA_OPEN_POPUP, openPopup)
+        }
+    }
+}

--- a/subprojects/android-test/ui-testing-core-app/src/main/res/layout/activity_rotate.xml
+++ b/subprojects/android-test/ui-testing-core-app/src/main/res/layout/activity_rotate.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".RotateOrientationActivity"
+    tools:ignore="HardcodedText">
+
+    <TextView
+        android:id="@+id/orientation_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        tools:text="Horizontal" />
+
+</LinearLayout>

--- a/subprojects/android-test/ui-testing-core-app/src/main/res/layout/popup_window.xml
+++ b/subprojects/android-test/ui-testing-core-app/src/main/res/layout/popup_window.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_margin="24dp"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/title"
+        android:padding="16dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="Title" />
+
+</LinearLayout>

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/espresso/action/OrientationChangeAction.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/espresso/action/OrientationChangeAction.kt
@@ -36,7 +36,7 @@ class OrientationChangeAction(private val orientation: Int? = null) : ViewAction
         when (val currentOrientation = activity.resources.configuration.orientation) {
             Configuration.ORIENTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
             Configuration.ORIENTATION_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            else -> throw IllegalStateException("illegal orientation: $currentOrientation")
+            else -> throw IllegalStateException("Unsupported orientation: $currentOrientation")
         }
 
     companion object {

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/KeyboardElement.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/KeyboardElement.kt
@@ -57,6 +57,7 @@ class KeyboardElement : PageObject() {
                 val activityHeight = content.rootView.height
                 val minimalKeyboardHeight = activityHeight * KEYBOARD_MINIMUM_HEIGHT_PERCENTAGE
 
+                // TODO: don't use hidden API or unseal it by me.weishu.reflection.Reflection
                 // If mAttachInfo is null we can't check keyboard position.
                 // https://issuetracker.google.com/u/1/issues/68137674
                 View::class.java.getDeclaredField("mAttachInfo").apply {


### PR DESCRIPTION
We change orientation inside Espresso action:

```kotlin
fun rotate() {
  onView(ViewMatchers.isRoot())
      .perform(OrientationChangeAction.toggle())
}
```

I've seen flakiness with cases with open dialogs:

```
androidx.test.espresso.base.RootViewPicker$RootViewWithoutFocusException: 
Waited for the root of the view hierarchy to have window focus and not request layout for 10 seconds. 
If you specified a non-default root matcher, it may be picking a root that never takes focus
```

Espresso tries to pick the best root view in [RootViewPicker](https://github.com/android/android-test/blob/master/espresso/core/java/androidx/test/espresso/base/RootViewPicker.java#L252)

Didn't find root causes of flakiness but added tests.