### PR TITLE
MBS-11678 Dump all windows hierarchy in case of failed tests

### DIFF
--- a/subprojects/test-runner/test-report/src/main/kotlin/com/avito/android/test/report/troubleshooting/dump/ViewHierarchyDumper.kt
+++ b/subprojects/test-runner/test-report/src/main/kotlin/com/avito/android/test/report/troubleshooting/dump/ViewHierarchyDumper.kt
@@ -1,14 +1,14 @@
 package com.avito.android.test.report.troubleshooting.dump
 
 import radiography.Radiography
-import radiography.ScanScopes.FocusedWindowScope
+import radiography.ScanScopes.AllWindowsScope
 import radiography.ViewStateRenderers
 
 object ViewHierarchyDumper {
 
     fun getDump(): String {
         return Radiography.scan(
-            scanScope = FocusedWindowScope,
+            scanScope = AllWindowsScope,
             viewStateRenderers = ViewStateRenderers.DefaultsIncludingPii
         )
     }


### PR DESCRIPTION
In the case of multiple windows, this will help to understand available roots.
See example problems in MBS-11678 description.

