### PR TITLE
MBS-11063 Don't run lint in CI steps tests

### DIFF
--- a/build-logic/gradle/src/main/kotlin/com/avito/android/CheckWrapper.kt
+++ b/build-logic/gradle/src/main/kotlin/com/avito/android/CheckWrapper.kt
@@ -50,7 +50,8 @@ abstract class CheckWrapper : DefaultTask() {
                         Inconsistency(
                             projectPath = projectPath,
                             reason = "project gradle version is '$expectedGradleVersion', " +
-                                "but ${project.relativePath(wrapperPropertiesFile)} points to another version: $distributionUrl"
+                                "but ${project.relativePath(wrapperPropertiesFile)} " +
+                                "points to another version: $distributionUrl"
                         )
                     )
                 }
@@ -62,7 +63,8 @@ abstract class CheckWrapper : DefaultTask() {
                         Inconsistency(
                             projectPath = projectPath,
                             reason = "gradle distribution type is '$expectedDistributionType', " +
-                                "but ${project.relativePath(wrapperPropertiesFile)} specifies another type: $distributionUrl"
+                                "but ${project.relativePath(wrapperPropertiesFile)} " +
+                                "specifies another type: $distributionUrl"
                         )
                     )
                 }
@@ -74,7 +76,8 @@ abstract class CheckWrapper : DefaultTask() {
                         Inconsistency(
                             projectPath = projectPath,
                             reason = "Expected gradle distribution url is '$expectedDistributionUrl', " +
-                                "but ${project.relativePath(wrapperPropertiesFile)} specifies different one: $distributionUrl"
+                                "but ${project.relativePath(wrapperPropertiesFile)} " +
+                                "specifies different one: $distributionUrl"
                         )
                     )
                 }

--- a/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/steps/LintCheckTest.kt
+++ b/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/steps/LintCheckTest.kt
@@ -5,7 +5,6 @@ import com.avito.test.gradle.TestResult
 import com.avito.test.gradle.gradlew
 import com.avito.test.gradle.module.AndroidAppModule
 import com.avito.test.gradle.plugin.plugins
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -28,7 +27,7 @@ internal class LintCheckTest {
         val buildResult = runBuild()
         buildResult.assertThat()
             .buildSuccessful()
-            .taskWithOutcome(":app:lintRelease", TaskOutcome.SUCCESS)
+            .tasksShouldBeTriggered(":app:lintRelease")
     }
 
     private fun runBuild(): TestResult {
@@ -36,6 +35,7 @@ internal class LintCheckTest {
             projectDir,
             "app:release",
             "-Pci=true",
+            dryRun = true,
         )
     }
 

--- a/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/steps/LintReportTest.kt
+++ b/subprojects/gradle/cd/src/gradleTest/kotlin/com/avito/ci/steps/LintReportTest.kt
@@ -5,7 +5,6 @@ import com.avito.test.gradle.TestResult
 import com.avito.test.gradle.gradlew
 import com.avito.test.gradle.module.AndroidAppModule
 import com.avito.test.gradle.plugin.plugins
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -28,8 +27,10 @@ internal class LintReportTest {
         val buildResult = runBuild()
         buildResult.assertThat()
             .buildSuccessful()
-            .taskWithOutcome(":app:lintRelease", TaskOutcome.SUCCESS)
-            .taskWithOutcome(":app:lintReportToChannel", TaskOutcome.SUCCESS)
+            .tasksShouldBeTriggered(
+                ":app:lintRelease",
+                ":app:lintReportToChannel"
+            )
     }
 
     private fun runBuild(): TestResult {
@@ -40,7 +41,8 @@ internal class LintReportTest {
             "-PbuildNumber=0",
             "-PteamcityBuildType=stubBuildType",
             "-PteamcityUrl=http://stub",
-            "-PteamcityBuildId=0"
+            "-PteamcityBuildId=0",
+            dryRun = true
         )
     }
 


### PR DESCRIPTION
I've got OOM in CI (build 24358432).

Don't see the need to really run lint in these tests. We care only about tasks but don't check lint results.