### PR TITLE
MBS-11808 Fix ScreenChecks for dialogs in Android 11

### DIFF
--- a/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsScreen.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsScreen.kt
@@ -1,14 +1,17 @@
 package com.avito.android.ui.test.dialog
 
 import androidx.test.espresso.matcher.ViewMatchers
-import com.avito.android.screen.Screen
-import com.avito.android.test.page_object.PageObject
+import com.avito.android.screen.ScreenChecks
+import com.avito.android.test.page_object.SimpleScreen
 import com.avito.android.test.page_object.ViewElement
 import com.avito.android.ui.R
 
-class DialogsScreen : Screen, PageObject() {
+class DialogsScreen : SimpleScreen() {
 
     override val rootId: Int = R.id.content
 
-    val content: ViewElement = element(ViewMatchers.withId(rootId))
+    val label: ViewElement = element(ViewMatchers.withId(R.id.label))
+
+    override val checks: ScreenChecks =
+        SimpleScreenChecks(screen = this, checkOnEachScreenInteraction = true)
 }

--- a/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsTest.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsTest.kt
@@ -1,6 +1,5 @@
 package com.avito.android.ui.test.dialog
 
-import androidx.test.espresso.NoMatchingViewException
 import com.avito.android.test.app.core.screenRule
 import com.avito.android.ui.DialogsActivity
 import com.avito.android.ui.test.Screen
@@ -17,7 +16,7 @@ class DialogsTest {
     fun matcher_with_default_root__success__no_dialog() {
         rule.launchActivity(null)
 
-        Screen.dialogsScreen.content.checks.isDisplayed()
+        Screen.dialogsScreen.label.checks.isDisplayed()
     }
 
     @Test
@@ -29,12 +28,12 @@ class DialogsTest {
     }
 
     @Test
-    fun matcher_with_default_root__no_matching_view_exception__dialog_is_open() {
+    fun matcher_with_default_root__assertion_error__dialog_is_open() {
         rule.launchActivity(
             DialogsActivity.intent(openDialog = true)
         )
-        assertThrows<NoMatchingViewException> {
-            Screen.dialogsScreen.content.checks.isDisplayed()
+        assertThrows<AssertionError> {
+            Screen.dialogsScreen.label.checks.isDisplayed()
         }
     }
 }

--- a/subprojects/android-test/ui-testing-core-app/src/main/res/layout/activity_dialogs.xml
+++ b/subprojects/android-test/ui-testing-core-app/src/main/res/layout/activity_dialogs.xml
@@ -9,7 +9,7 @@
     tools:ignore="HardcodedText">
 
     <TextView
-        android:id="@+id/orientation_label"
+        android:id="@+id/label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/screen/Screen.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/screen/Screen.kt
@@ -1,5 +1,7 @@
 package com.avito.android.screen
 
+import android.view.View
+
 /**
  * Single "screen" of an app
  * Could be activity or fragment or view based
@@ -12,27 +14,10 @@ interface Screen {
     /**
      * R.id of root view in hierarchy of a screen
      * Used to determine if screen is presented to user (opened)
-     *
-     * Also used to link "Screen" PageObject and "Screen" (android.view.View) in app code
-     * for impact analysis in ui tests
-     *
-     * <WARNING>
-     * Use only direct implementation(ex: rootId = R.id.root)!
-     * Not lateinit or custom getters to init property
-     * Static code analyzer for impact analyze works on bytecode level and couldn't extract value otherwise
-     *
-     * if apps's screen is in separate module, there can be multiple equal id's, like:
-     *  com.avito.android.authorization.R.id
-     *  com.avito.android.R.id
-     * Even worse, if there is a name clash (ex: id.root in multiple modules) LAST ONE!
-     *  ends up in com.avito.android.R.id
-     * Last one means last module in resource merge process
-     * We could get different isOpened results based on module merge ordering :crazy:
-     * So you better import fully qualified package name for R class of your module in Screen implementation
-     * </WARNING>
      */
     val rootId: Int
 
+    // TODO: remove default implementation after migrating clients to specific implementations in MBS-11808
     val checks: ScreenChecks
         get() = StrictScreenChecks(screen = this, checkOnEachScreenInteraction = false)
 
@@ -41,6 +26,6 @@ interface Screen {
         /**
          * means that all tests that calls this screen will be run regardless of code changes (no impact analysis)
          */
-        const val UNKNOWN_ROOT_ID: Int = -1
+        const val UNKNOWN_ROOT_ID: Int = View.NO_ID
     }
 }

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/Alert.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/Alert.kt
@@ -4,17 +4,10 @@ import androidx.appcompat.widget.AlertDialogLayout
 import androidx.appcompat.widget.DialogTitle
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import com.avito.android.test.InteractionContext
-import com.avito.android.test.context.DialogInteractionContext
 
-class Alert : PageObject() {
-
-    @Suppress("RedundantModalityModifier")
-    final override val interactionContext: InteractionContext
-        get() = DialogInteractionContext(
-            matcher = isAssignableFrom(AlertDialogLayout::class.java)
-        )
-
+class Alert : DialogScreen(
+    matcher = isAssignableFrom(AlertDialogLayout::class.java)
+) {
     val messageElement: ViewElement = element(withId(android.R.id.message))
     val title: ViewElement = element(isAssignableFrom(DialogTitle::class.java))
     val okButton: ViewElement = element(withId(android.R.id.button1))

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/DialogScreen.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/DialogScreen.kt
@@ -1,0 +1,42 @@
+package com.avito.android.test.page_object
+
+import android.view.View
+import androidx.annotation.CallSuper
+import com.avito.android.screen.BaseScreenChecks
+import com.avito.android.screen.Screen
+import com.avito.android.screen.ScreenChecks
+import com.avito.android.test.InteractionContext
+import com.avito.android.test.context.DialogInteractionContext
+import org.hamcrest.Matcher
+
+abstract class DialogScreen(
+    matcher: Matcher<View>
+) : PageObject(), Screen {
+
+    override val rootId: Int = Screen.UNKNOWN_ROOT_ID
+
+    override val interactionContext: InteractionContext by lazy {
+        DialogInteractionContext(matcher) {
+            if (checks.checkOnEachScreenInteraction) {
+                checks.isScreenOpened()
+            }
+        }
+    }
+
+    override val checks: ScreenChecks =
+        DialogScreenChecks(screen = this, checkOnEachScreenInteraction = true)
+
+    val rootElement = element<ViewElement>()
+
+    open class DialogScreenChecks(
+        screen: DialogScreen,
+        override val checkOnEachScreenInteraction: Boolean = true
+    ) : BaseScreenChecks<DialogScreen>(screen) {
+
+        @CallSuper
+        override fun screenOpenedCheck() {
+            screen.rootElement.checks.exists()
+            screen.rootElement.checks.isDisplayed()
+        }
+    }
+}

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/PageObject.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/PageObject.kt
@@ -9,6 +9,7 @@ import org.hamcrest.Matcher
 
 abstract class PageObject {
 
+    // TODO: remove default implementation after migrating clients to specific implementations in MBS-11808
     open val interactionContext: InteractionContext by lazy {
         if (this is Screen) {
             SimpleInteractionContext(ViewMatchers.isRoot()) {

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/SimpleScreen.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/SimpleScreen.kt
@@ -1,0 +1,40 @@
+package com.avito.android.test.page_object
+
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.avito.android.screen.BaseScreenChecks
+import com.avito.android.screen.Screen
+import com.avito.android.test.InteractionContext
+import com.avito.android.test.SimpleInteractionContext
+
+abstract class SimpleScreen : PageObject(), Screen {
+
+    override val interactionContext: InteractionContext by lazy {
+        SimpleInteractionContext(ViewMatchers.isRoot()) {
+            if (checks.checkOnEachScreenInteraction) {
+                checks.isScreenOpened()
+            }
+        }
+    }
+
+    override val checks: com.avito.android.screen.ScreenChecks =
+        SimpleScreenChecks(screen = this, checkOnEachScreenInteraction = false)
+
+    val rootElement: ViewElement by lazy {
+        // rootId property is initialized after rootElement property
+        element(withId(rootId))
+    }
+
+    open class SimpleScreenChecks<T : SimpleScreen>(
+        screen: T,
+        override val checkOnEachScreenInteraction: Boolean = false
+    ) : BaseScreenChecks<T>(screen) {
+
+        override fun screenOpenedCheck() {
+            if (screen.rootId != Screen.UNKNOWN_ROOT_ID) {
+                screen.rootElement.checks.exists()
+                screen.rootElement.checks.isDisplayed()
+            }
+        }
+    }
+}

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/ViewElement.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/ViewElement.kt
@@ -20,12 +20,13 @@ open class ViewElement : PageObjectElement, Actions {
     override val actions: Actions
     override val checks: Checks
 
-    /**
-     * TODO: make this constructor private and remove matcher
-     * Don't use this constructor. It leads to actions and checks in a wrong screen. " +
-    "Inside [PageObject] use [element] to create an instance with child interaction context. " +
-    "From custom class use ViewElement(interactionContext)
-     */
+    // TODO: make this constructor private and remove matcher
+    @Deprecated(
+        "Use constructor with interaction context. " +
+            "Otherwise, you can get actions and checks in a wrong screen or window." +
+            "See [PageObject.element] to create an instance with correct interaction context inside page objects." +
+            "For a custom class use `ViewElement(interactionContext)`"
+    )
     constructor(
         matcher: Matcher<View>,
         interactionContext: InteractionContext = SimpleInteractionContext(matcher),
@@ -38,6 +39,7 @@ open class ViewElement : PageObjectElement, Actions {
         this.checks = checks
     }
 
+    @Suppress("DEPRECATION")
     constructor(interactionContext: InteractionContext) :
         this(
             NoViewMatcher(),
@@ -46,6 +48,7 @@ open class ViewElement : PageObjectElement, Actions {
             ChecksImpl(interactionContext)
         )
 
+    @Suppress("DEPRECATION")
     constructor(interactionContext: InteractionContext, checks: Checks) :
         this(NoViewMatcher(), interactionContext, ActionsImpl(interactionContext), checks)
 

--- a/subprojects/common/junit-utils/src/main/java/ru/avito/util/Asserts.kt
+++ b/subprojects/common/junit-utils/src/main/java/ru/avito/util/Asserts.kt
@@ -13,7 +13,7 @@ public inline fun <T : Throwable> assertThrows(expectedType: Class<T>, executabl
         } else {
             throw AssertionFailedError(
                 "Unexpected exception type thrown. " +
-                    "Expected: $expectedType , but was ${actualException.javaClass}"
+                    "Expected: $expectedType , but was ${actualException.javaClass}: $actualException"
             )
         }
     }


### PR DESCRIPTION
### The problem

`ScreenChecks` ignores interaction context. It leads to an interaction on a wrong window in dialogs in Android 11.

### Changes

The key ideas: 

- To remove default implementations: `ScreenChecks` from `Screen` and  `InteractionContext` from `PageObject`.
They do wrong assumptions about use cases and force to override implementation in an inconvenient way.

```kotlin
abstract class PageObject {

    open val interactionContext: InteractionContext by lazy {
        if (this is Screen) {
            SimpleInteractionContext(ViewMatchers.isRoot()) {
                if (checks.checkOnEachScreenInteraction) {
                    checks.isScreenOpened()
                }
            }
        } else {
            SimpleInteractionContext(ViewMatchers.isRoot())
        }
    }
```

- Wire appropriate implementations of `ScreenChecks` and `InteractionContext` for specific use cases. Intersection of `Screen` and `PageObject` gives us all needed information.

### Use cases

1. Page object for a reqular screen

Before it was implemented in two ways:

- `MyScreen: PageObject`
- `MyScreen: PageObject, Screen`

After it will be only one way:

`MyScreen: SimpleScreen`


2. Page object for a dialog

Before it was implemented in two ways:

- `MyDialog: PageObject`
- `MyDialog: PageObject, Screen`

After it will be only one way:

`MyDialog: DialogScreen`

### FAQ

- What if I have `PageObject` that is not a `Screen`? Didn't find any example. In all cases it was a `ViewElement` inside other `PageObject`. If we find the opposite, we will support it explicitly.
- `PopupWindow` support will be in another PR to reduce the scope of change
- How do I force use cases for clients? By removing default implementation from `PageObject` and `Screen`.