### PR TITLE
MBS-11808 Fix ScreenChecks for a PopupWindow page object

### DIFF
--- a/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsScreen.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsScreen.kt
@@ -2,6 +2,7 @@ package com.avito.android.ui.test.dialog
 
 import androidx.test.espresso.matcher.ViewMatchers
 import com.avito.android.screen.ScreenChecks
+import com.avito.android.test.page_object.DialogScreen
 import com.avito.android.test.page_object.PopupScreen
 import com.avito.android.test.page_object.SimpleScreen
 import com.avito.android.test.page_object.ViewElement
@@ -24,4 +25,16 @@ class DialogsScreen : SimpleScreen() {
 
         val label: ViewElement = element(ViewMatchers.withId(R.id.label))
     }
+}
+
+class DialogScreenWithDialogRoot : DialogScreen(
+    ViewMatchers.withId(R.id.content)
+) {
+    val label: ViewElement = element(ViewMatchers.withId(R.id.label))
+}
+
+class DialogScreenWithPopupRoot : PopupScreen(
+    ViewMatchers.withId(R.id.content)
+) {
+    val label: ViewElement = element(ViewMatchers.withId(R.id.label))
 }

--- a/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsScreen.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsScreen.kt
@@ -2,6 +2,7 @@ package com.avito.android.ui.test.dialog
 
 import androidx.test.espresso.matcher.ViewMatchers
 import com.avito.android.screen.ScreenChecks
+import com.avito.android.test.page_object.PopupScreen
 import com.avito.android.test.page_object.SimpleScreen
 import com.avito.android.test.page_object.ViewElement
 import com.avito.android.ui.R
@@ -12,6 +13,15 @@ class DialogsScreen : SimpleScreen() {
 
     val label: ViewElement = element(ViewMatchers.withId(R.id.label))
 
+    val popup = Popup()
+
     override val checks: ScreenChecks =
         SimpleScreenChecks(screen = this, checkOnEachScreenInteraction = true)
+
+    class Popup : PopupScreen(
+        matcher = ViewMatchers.withId(R.id.popup_content)
+    ) {
+
+        val label: ViewElement = element(ViewMatchers.withId(R.id.label))
+    }
 }

--- a/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsTest.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsTest.kt
@@ -1,5 +1,6 @@
 package com.avito.android.ui.test.dialog
 
+import androidx.test.espresso.NoMatchingRootException
 import com.avito.android.test.app.core.screenRule
 import com.avito.android.ui.DialogsActivity
 import com.avito.android.ui.test.Screen
@@ -13,14 +14,43 @@ class DialogsTest {
     val rule = screenRule<DialogsActivity>()
 
     @Test
-    fun matcher_with_default_root__success__no_dialog() {
+    fun check_regular_window__success__matcher_with_default_root() {
         rule.launchActivity(null)
 
         Screen.dialogsScreen.label.checks.isDisplayed()
     }
 
     @Test
-    fun matcher_with_dialog_root__success__dialog_is_open() {
+    fun check_regular_window__fail__matcher_with_dialog_root() {
+        rule.launchActivity(null)
+
+        assertThrows<NoMatchingRootException> {
+            DialogScreenWithDialogRoot().label.checks.isDisplayed()
+        }
+    }
+
+    @Test
+    fun check_regular_window__fail__matcher_with_popup_window() {
+        rule.launchActivity(null)
+
+        assertThrows<NoMatchingRootException> {
+            DialogScreenWithPopupRoot().label.checks.isDisplayed()
+        }
+    }
+
+    @Test
+    fun check_regular_window__fail__matcher_with_default_root_and_dialog_is_open() {
+        rule.launchActivity(
+            DialogsActivity.intent(openDialog = true)
+        )
+        // Espresso pick's wrongly dialog window
+        assertThrows<AssertionError> {
+            Screen.dialogsScreen.label.checks.isDisplayed()
+        }
+    }
+
+    @Test
+    fun check_dialog_window__success__matcher_with_dialog_root() {
         rule.launchActivity(
             DialogsActivity.intent(openDialog = true)
         )
@@ -28,17 +58,7 @@ class DialogsTest {
     }
 
     @Test
-    fun matcher_with_default_root__assertion_error__dialog_is_open() {
-        rule.launchActivity(
-            DialogsActivity.intent(openDialog = true)
-        )
-        assertThrows<AssertionError> {
-            Screen.dialogsScreen.label.checks.isDisplayed()
-        }
-    }
-
-    @Test
-    fun matcher_with_popup_window__success__popup_is_open() {
+    fun check_popup_window__success__matcher_with_popup_window() {
         rule.launchActivity(
             DialogsActivity.intent(openPopup = true)
         )

--- a/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsTest.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/androidTest/kotlin/com/avito/android/ui/test/dialog/DialogsTest.kt
@@ -36,4 +36,12 @@ class DialogsTest {
             Screen.dialogsScreen.label.checks.isDisplayed()
         }
     }
+
+    @Test
+    fun matcher_with_popup_window__success__popup_is_open() {
+        rule.launchActivity(
+            DialogsActivity.intent(openPopup = true)
+        )
+        Screen.dialogsScreen.popup.label.checks.isDisplayed()
+    }
 }

--- a/subprojects/android-test/ui-testing-core-app/src/main/kotlin/com/avito/android/ui/DialogsActivity.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/main/kotlin/com/avito/android/ui/DialogsActivity.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AppCompatActivity
 class DialogsActivity : AppCompatActivity() {
 
     private var dialog: Dialog? = null
+    private var popup: PopupWindow? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,6 +31,7 @@ class DialogsActivity : AppCompatActivity() {
 
     override fun onStop() {
         dialog?.dismiss()
+        popup?.dismiss()
         super.onStop()
     }
 
@@ -55,16 +57,19 @@ class DialogsActivity : AppCompatActivity() {
 
             val view = LayoutInflater.from(this).inflate(R.layout.popup_window, null)
 
+            this.popup?.dismiss()
+
             val popup = PopupWindow(
                 view,
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
             )
             popup.setBackgroundDrawable(ColorDrawable(Color.GREEN))
-            view.findViewById<TextView>(R.id.title).text = "Popup Window content"
+            view.findViewById<TextView>(R.id.label).text = "Popup Window content"
 
             content.post {
                 popup.showAtLocation(content, Gravity.CENTER, 0, 0)
+                this.popup = popup
             }
         }
     }

--- a/subprojects/android-test/ui-testing-core-app/src/main/res/layout/popup_window.xml
+++ b/subprojects/android-test/ui-testing-core-app/src/main/res/layout/popup_window.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/popup_content"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_margin="24dp"
     android:orientation="vertical">
 
     <TextView
-        android:id="@+id/title"
+        android:id="@+id/label"
         android:padding="16dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/context/PopupInteractionContext.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/context/PopupInteractionContext.kt
@@ -7,7 +7,9 @@ import org.hamcrest.Matcher
 
 class PopupInteractionContext(
     matcher: Matcher<View>,
+    precondition: () -> Unit = {}
 ) : SimpleInteractionContext(
     matcher = matcher,
-    rootMatcher = RootMatchers.isPlatformPopup()
+    rootMatcher = RootMatchers.isPlatformPopup(),
+    precondition = precondition
 )

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/Alert.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/Alert.kt
@@ -5,7 +5,7 @@ import androidx.appcompat.widget.DialogTitle
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.withId
 
-class Alert : DialogScreen(
+open class Alert : DialogScreen(
     matcher = isAssignableFrom(AlertDialogLayout::class.java)
 ) {
     val messageElement: ViewElement = element(withId(android.R.id.message))

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/DialogScreen.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/DialogScreen.kt
@@ -13,7 +13,7 @@ abstract class DialogScreen(
     matcher: Matcher<View>
 ) : PageObject(), Screen {
 
-    override val rootId: Int = Screen.UNKNOWN_ROOT_ID
+    final override val rootId: Int = Screen.UNKNOWN_ROOT_ID
 
     override val interactionContext: InteractionContext by lazy {
         DialogInteractionContext(matcher) {

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/PopupScreen.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/PopupScreen.kt
@@ -13,7 +13,7 @@ abstract class PopupScreen(
     matcher: Matcher<View>
 ) : PageObject(), Screen {
 
-    override val rootId: Int = Screen.UNKNOWN_ROOT_ID
+    final override val rootId: Int = Screen.UNKNOWN_ROOT_ID
 
     override val interactionContext: InteractionContext by lazy {
         PopupInteractionContext(matcher) {

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/PopupScreen.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/page_object/PopupScreen.kt
@@ -1,0 +1,42 @@
+package com.avito.android.test.page_object
+
+import android.view.View
+import androidx.annotation.CallSuper
+import com.avito.android.screen.BaseScreenChecks
+import com.avito.android.screen.Screen
+import com.avito.android.screen.ScreenChecks
+import com.avito.android.test.InteractionContext
+import com.avito.android.test.context.PopupInteractionContext
+import org.hamcrest.Matcher
+
+abstract class PopupScreen(
+    matcher: Matcher<View>
+) : PageObject(), Screen {
+
+    override val rootId: Int = Screen.UNKNOWN_ROOT_ID
+
+    override val interactionContext: InteractionContext by lazy {
+        PopupInteractionContext(matcher) {
+            if (checks.checkOnEachScreenInteraction) {
+                checks.isScreenOpened()
+            }
+        }
+    }
+
+    override val checks: ScreenChecks =
+        PopupScreenChecks(screen = this, checkOnEachScreenInteraction = true)
+
+    val rootElement = element<ViewElement>()
+
+    open class PopupScreenChecks(
+        screen: PopupScreen,
+        override val checkOnEachScreenInteraction: Boolean = true
+    ) : BaseScreenChecks<PopupScreen>(screen) {
+
+        @CallSuper
+        override fun screenOpenedCheck() {
+            screen.rootElement.checks.exists()
+            screen.rootElement.checks.isDisplayed()
+        }
+    }
+}


### PR DESCRIPTION
Added page object for PopupWindow.
It will reduce a boilerplate in clients (e.g. `TooltipElement` in avito repository).