### PR TITLE
MBS-11769 optimize gradle tests run

### DIFF
--- a/build-logic-settings/gradle.properties
+++ b/build-logic-settings/gradle.properties
@@ -20,3 +20,6 @@ org.gradle.caching=true
 # from common properties
 # https://github.com/gradle/gradle/issues/4823
 org.gradle.configureondemand=false
+# from common properties
+# Limited locally, because unlimited workers will hang pc on parallel gradleTest execution
+org.gradle.workers.max=4

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -20,3 +20,6 @@ org.gradle.caching=true
 # from common properties
 # https://github.com/gradle/gradle/issues/4823
 org.gradle.configureondemand=false
+# from common properties
+# Limited locally, because unlimited workers will hang pc on parallel gradleTest execution
+org.gradle.workers.max=4

--- a/build-logic/testing/src/main/kotlin/convention.gradle-testing.gradle.kts
+++ b/build-logic/testing/src/main/kotlin/convention.gradle-testing.gradle.kts
@@ -64,10 +64,7 @@ val gradleTestTask = tasks.register<Test>("gradleTest") {
     )
 
     minHeapSize = "128m"
-    /**
-     * Before was 256m, gradle tests with lint execution got the OOM
-     */
-    maxHeapSize = "512m"
+    maxHeapSize = "256m"
 
     systemProperty("rootDir", "${project.rootDir}")
     systemProperty("buildDir", "$buildDir")

--- a/ci/gradle.properties
+++ b/ci/gradle.properties
@@ -6,3 +6,4 @@ org.gradle.unsafe.configuration-cache-problems=fail
 avitoGithub.gradle.buildCache.remote.push=true
 # For more hermetic builds in containers
 android.builder.sdkDownload=false
+org.gradle.workers.max=28

--- a/conf/common-gradle.properties
+++ b/conf/common-gradle.properties
@@ -16,3 +16,5 @@ org.gradle.parallel=true
 org.gradle.caching=true
 # https://github.com/gradle/gradle/issues/4823
 org.gradle.configureondemand=false
+# Limited locally, because unlimited workers will hang pc on parallel gradleTest execution
+org.gradle.workers.max=4

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,6 @@ org.gradle.caching=true
 # from common properties
 # https://github.com/gradle/gradle/issues/4823
 org.gradle.configureondemand=false
+# from common properties
+# Limited locally, because unlimited workers will hang pc on parallel gradleTest execution
+org.gradle.workers.max=4

--- a/samples/gradle.properties
+++ b/samples/gradle.properties
@@ -24,3 +24,6 @@ avito.logging.verbosity=WARNING
 avito.build=local
 #
 android.useAndroidX=true
+# from common properties
+# Limited locally, because unlimited workers will hang pc on parallel gradleTest execution
+org.gradle.workers.max=4

--- a/subprojects/gradle.properties
+++ b/subprojects/gradle.properties
@@ -40,3 +40,6 @@ teamcityUrl=http://stub
 buildNumber=1
 teamcityBuildType=BT
 gitBranch=develop
+# from common properties
+# Limited locally, because unlimited workers will hang pc on parallel gradleTest execution
+org.gradle.workers.max=4

--- a/subprojects/gradle/test-project/src/main/kotlin/com/avito/test/gradle/TestProjectGenerator.kt
+++ b/subprojects/gradle/test-project/src/main/kotlin/com/avito/test/gradle/TestProjectGenerator.kt
@@ -66,6 +66,15 @@ public class TestProjectGenerator(
     override val useKts: Boolean = false,
     public val localBuildCache: File? = null,
     public val androidHome: String? = null,
+    /**
+     * https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
+     * default is -Xmx512m "-XX:MaxMetaspaceSize=256m
+     * bumped because of Metaspace issues
+     * https://github.com/gradle/gradle/issues/10527
+     */
+    public val gradleProperties: Map<String, String> = mapOf(
+        "org.gradle.jvmargs" to "-Xmx1g -XX:MaxMetaspaceSize=512m"
+    )
 ) : Module {
 
     private val logger: Logger = StubLoggerFactory.create<TestProjectGenerator>()
@@ -135,6 +144,15 @@ buildCache {
                         *build/
                         """.trimIndent()
             )
+
+            FileOutputStream(file("gradle.properties")).use { file ->
+                Properties().run {
+                    gradleProperties.forEach { (key, value) ->
+                        setProperty(key, value)
+                    }
+                    store(file, null)
+                }
+            }
 
             FileOutputStream(file("local.properties")).use { file ->
                 Properties().run {


### PR DESCRIPTION
## limit gradle workers to 4 locally

Why 4? Empirically doesn't cause hangs on my pc, but still have some parallelism for build.
As far as i know we have values between 12 and 32 in our team (6 cpu + hyperthreading on mac's minimum)
Could tune this value higher, but should be done with mac

## more memory for gradle daemons in tests to avoid OOM metaspace

Previous tweak affected only test process, but OOM was in gradle daemon, spawned for test 