### PR TITLE
MBS-11914 update radiography

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ espressoCore = { module = "androidx.test.espresso:espresso-core", version.ref = 
 espressoWeb = { module = "androidx.test.espresso:espresso-web", version.ref = "espresso" }
 espressoIntents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso" }
 espressoDescendantActions = "com.forkingcode.espresso.contrib:espresso-descendant-actions:1.4.0"
-radiography = "com.squareup.radiography:radiography:2.4.0"
+radiography = "com.squareup.radiography:radiography:2.4.1"
 rx3Ilder = "com.squareup.rx.idler:rx3-idler:0.11.0"
 r8 = "com.android.tools:r8:2.2.41"
 proguardRetrace = "net.sf.proguard:proguard-retrace:6.2.2"


### PR DESCRIPTION
https://github.com/square/radiography/blob/main/CHANGELOG.md#version-241

bugfix: avoid main thread check crashes

Stop throwing when not on main thread. While Curtains APIs should be used from the main thread, there are a number edge cases as well as bugs in consuming SDKs / apps and the Android Framework SDKs that can trigger calls from the wrong thread, and in many cases there isn't much developers can do, so Curtains is relaxing the constraint and doing a best effort approach.