### PR TITLE
MBS-11834 add build convinience messages

### DIFF
--- a/build-logic/testing/src/main/kotlin/com/avito/android/test/Test.kt
+++ b/build-logic/testing/src/main/kotlin/com/avito/android/test/Test.kt
@@ -2,9 +2,25 @@ package com.avito.android.test
 
 import org.gradle.api.tasks.testing.Test
 
+/**
+ * @return true if value is set
+ */
 @Suppress("unused")
-fun Test.applyOptionalSystemProperty(name: String) {
+fun Test.applyOptionalSystemProperty(name: String): Boolean {
     if (project.hasProperty(name)) {
-        project.property(name)?.toString()?.let { value -> systemProperty(name, value) }
+        project.property(name)?.toString()?.let { value ->
+            systemProperty(name, value)
+            return true
+        }
     }
+    return false
+}
+
+/**
+ * Try to set multiple system properties with names [name]
+ * Calls [onMissing] with missing properties
+ */
+fun Test.applySystemProperties(vararg name: String, onMissing: (missing: Set<String>) -> Unit) {
+    val result = name.associate { it to applyOptionalSystemProperty(it) }
+    onMissing(result.filter { !it.value }.keys)
 }

--- a/samples/test-runner/build.gradle.kts
+++ b/samples/test-runner/build.gradle.kts
@@ -47,7 +47,10 @@ instrumentation {
     }
 
     val credentials = project.kubernetesCredentials
-    if (credentials is KubernetesCredentials.Service || credentials is KubernetesCredentials.Config) {
+    if (credentials !is KubernetesCredentials.Service && credentials !is KubernetesCredentials.Config) {
+        // todo fix this in MBS-11834
+        logger.warn("Instrumentation tasks are not created because kubernetes credentials not set")
+    } else {
 
         val emulator29 = CloudEmulator(
             name = "api29",
@@ -58,6 +61,7 @@ instrumentation {
             cpuCoresLimit = "1.3",
             memoryLimit = "4Gi"
         )
+
         val emulator30 = CloudEmulator(
             name = "api30",
             api = 30,

--- a/subprojects/android-test/ui-testing-core-app/build.gradle.kts
+++ b/subprojects/android-test/ui-testing-core-app/build.gradle.kts
@@ -98,7 +98,10 @@ instrumentation {
     }
 
     val credentials = project.kubernetesCredentials
-    if (credentials is Service || credentials is KubernetesCredentials.Config) {
+    if (credentials !is Service && credentials !is KubernetesCredentials.Config) {
+        // todo fix this in MBS-11834
+        logger.warn("Instrumentation tasks are not created because kubernetes credentials not set")
+    } else {
 
         afterEvaluate {
             tasks.named("check").dependsOn(tasks.named("instrumentationUi"))

--- a/subprojects/gradle/slack/build.gradle.kts
+++ b/subprojects/gradle/slack/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.avito.android.test.applyOptionalSystemProperty
+import com.avito.android.test.applySystemProperties
 
 plugins {
     id("convention.kotlin-jvm")
@@ -29,8 +29,17 @@ dependencies {
 }
 
 tasks.named<Test>("integrationTest").configure {
-    applyOptionalSystemProperty("avito.slack.test.channelId")
-    applyOptionalSystemProperty("avito.slack.test.channel")
-    applyOptionalSystemProperty("avito.slack.test.token")
-    applyOptionalSystemProperty("avito.slack.test.workspace")
+
+    applySystemProperties(
+        "avito.slack.test.channelId",
+        "avito.slack.test.channel",
+        "avito.slack.test.token",
+        "avito.slack.test.workspace"
+    ) { missing ->
+        require(missing.isEmpty()) {
+            "$path:integrationTest requires additional properties to be applied\n" +
+                "missing values are: $missing\n" +
+                "It should be added to ~/.gradle/gradle.properties"
+        }
+    }
 }


### PR DESCRIPTION
- add log message for missing kubernetes credentials;
- throw meaningful exception on missing properties for integration tests