### PR TITLE
MBS-11997 remove warnings spam on ciSteps local applying

### DIFF
--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/CiStepsPlugin.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/CiStepsPlugin.kt
@@ -27,7 +27,7 @@ public class CiStepsPlugin : Plugin<Project> {
         project.extensions.add("builds", buildContainer)
 
         if (project.buildEnvironment !is BuildEnvironment.CI) {
-            logger.warn("The plugin is applied but it's disabled. Add -Pci=true to enable the plugin")
+            logger.info("The plugin is applied but it's disabled. Add -Pci=true to enable the plugin")
             return
         }
 


### PR DESCRIPTION
reason: non-actionable
how to see these messages locally: use verbose logging https://avito-tech.github.io/avito-android/contributing/Logging/#verbose-mode