### PR TITLE
MBS-11967 Remove missing dependencies from lock files

### DIFF
--- a/samples/test-runner/locking/buildscript-gradle.lockfile
+++ b/samples/test-runner/locking/buildscript-gradle.lockfile
@@ -43,7 +43,6 @@ com.fasterxml.jackson.core:jackson-databind:2.9.10.8=classpath
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.10=classpath
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.10=classpath
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.9.10=classpath
-com.fasterxml.jackson:jackson-bom:2.9.10.20210106=classpath
 com.fkorotkov:kubernetes-dsl:2.7.1=classpath
 com.github.gundy:semver4j:0.16.4=classpath
 com.github.mifmif:generex:1.0.2=classpath

--- a/subprojects/signer/locking/buildscript-gradle.lockfile
+++ b/subprojects/signer/locking/buildscript-gradle.lockfile
@@ -36,7 +36,6 @@ com.android.tools:sdk-common:30.0.2=classpath
 com.android.tools:sdklib:30.0.2=classpath
 com.android:signflinger:7.0.2=classpath
 com.android:zipflinger:7.0.2=classpath
-com.fasterxml.jackson:jackson-bom:2.9.10.20210106=classpath
 com.github.gundy:semver4j:0.16.4=classpath
 com.github.salomonbrys.kotson:kotson:2.5.0=classpath
 com.google.android:annotations:4.1.1.4=classpath


### PR DESCRIPTION
```
A problem occurred configuring project ':subprojects:signer'.
> Could not resolve all artifacts for configuration ':subprojects:signer:classpath'.
   > Did not resolve 'com.fasterxml.jackson:jackson-bom:2.9.10.20210106' which is part of the dependency lock state
```
This dependency is not used but declared in lock files.