### PR TITLE
MBS-12013 Make included builds fully cacheable

### DIFF
--- a/build-logic-settings/cache-plugin/src/main/kotlin/convention-cache.settings.gradle.kts
+++ b/build-logic-settings/cache-plugin/src/main/kotlin/convention-cache.settings.gradle.kts
@@ -1,3 +1,4 @@
+// See also duplicated settings in parent project
 @Suppress("UnstableApiUsage")
 val avitoGithubRemoteCacheHost: Provider<String> = settings.providers
     .environmentVariable("GRADLE_CACHE_NODE_HOST")

--- a/build-logic-settings/gradle.properties
+++ b/build-logic-settings/gradle.properties
@@ -32,3 +32,7 @@ android.experimental.cacheCompileLibResources=true
 # from common properties
 # Disabled because of bug: https://github.com/gradle/gradle/issues/18294
 org.gradle.vfs.watch=false
+# from common properties
+# To enable fail-fast checks for type-safe accessors.
+# To make GeneratePrecompiledScriptPluginAccessors cacheable.
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -46,6 +46,27 @@ dependencyResolutionManagement {
     }
 }
 
+// Duplicated settings because they are not inherited from root project
+// as described in https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_composite
+// https://github.com/gradle/gradle/issues/18511
+@Suppress("UnstableApiUsage")
+val avitoGithubRemoteCacheHost: Provider<String> = settings.providers
+    .environmentVariable("GRADLE_CACHE_NODE_HOST")
+    .forUseAtConfigurationTime()
+
+val avitoGithubRemoteCachePush: String =
+    extra.properties.getOrDefault("avitoGithub.gradle.buildCache.remote.push", "false").toString()
+
+buildCache {
+    remote<HttpBuildCache> {
+        setUrl("http://${avitoGithubRemoteCacheHost.orNull}/cache/")
+        isEnabled = avitoGithubRemoteCacheHost.orNull != null
+        isPush = avitoGithubRemoteCachePush.toBoolean()
+        isAllowUntrustedServer = true
+        isAllowInsecureProtocol = true
+    }
+}
+
 include("cache-plugin")
 include("dependency-plugin")
 include("scan-plugin")

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -32,3 +32,7 @@ android.experimental.cacheCompileLibResources=true
 # from common properties
 # Disabled because of bug: https://github.com/gradle/gradle/issues/18294
 org.gradle.vfs.watch=false
+# from common properties
+# To enable fail-fast checks for type-safe accessors.
+# To make GeneratePrecompiledScriptPluginAccessors cacheable.
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/conf/common-gradle.properties
+++ b/conf/common-gradle.properties
@@ -24,3 +24,6 @@ android.experimental.enableSourceSetPathsMap=true
 android.experimental.cacheCompileLibResources=true
 # Disabled because of bug: https://github.com/gradle/gradle/issues/18294
 org.gradle.vfs.watch=false
+# To enable fail-fast checks for type-safe accessors.
+# To make GeneratePrecompiledScriptPluginAccessors cacheable.
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,7 @@ android.experimental.cacheCompileLibResources=true
 # from common properties
 # Disabled because of bug: https://github.com/gradle/gradle/issues/18294
 org.gradle.vfs.watch=false
+# from common properties
+# To enable fail-fast checks for type-safe accessors.
+# To make GeneratePrecompiledScriptPluginAccessors cacheable.
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/samples/gradle.properties
+++ b/samples/gradle.properties
@@ -36,3 +36,7 @@ android.experimental.cacheCompileLibResources=true
 # from common properties
 # Disabled because of bug: https://github.com/gradle/gradle/issues/18294
 org.gradle.vfs.watch=false
+# from common properties
+# To enable fail-fast checks for type-safe accessors.
+# To make GeneratePrecompiledScriptPluginAccessors cacheable.
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/subprojects/gradle.properties
+++ b/subprojects/gradle.properties
@@ -52,3 +52,7 @@ android.experimental.cacheCompileLibResources=true
 # from common properties
 # Disabled because of bug: https://github.com/gradle/gradle/issues/18294
 org.gradle.vfs.watch=false
+# from common properties
+# To enable fail-fast checks for type-safe accessors.
+# To make GeneratePrecompiledScriptPluginAccessors cacheable.
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true


### PR DESCRIPTION
`./gradlew help` now has 100% cache hit rate