### PR TITLE
MBS-12251 [Instrumentation plugin] expose suppressFlaky/suppressFailure properties

### DIFF
--- a/subprojects/test-runner/instrumentation-tests/src/gradleTest/kotlin/com/avito/instrumentation/RunnerInputParamsTest.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/gradleTest/kotlin/com/avito/instrumentation/RunnerInputParamsTest.kt
@@ -265,11 +265,11 @@ internal class RunnerInputParamsTest {
             },
             Case("suppress failure") {
                 assertThat(it.suppressFailure)
-                    .isFalse()
+                    .isTrue()
             },
             Case("suppress flaky") {
                 assertThat(it.suppressFlaky)
-                    .isFalse()
+                    .isTrue()
             },
             Case("impact analysis result runOnlyChangedTests flag") {
                 assertThat(it.impactAnalysisResult.runOnlyChangedTests)

--- a/subprojects/test-runner/instrumentation-tests/src/gradleTest/kotlin/com/avito/instrumentation/StubConfig.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/gradleTest/kotlin/com/avito/instrumentation/StubConfig.kt
@@ -38,6 +38,9 @@ internal val kotlinStubConfig = """
   |                "override" to "overrideInConfiguration"
   |            )
   |
+  |            suppressFlaky.set(true)
+  |            suppressFailure.set(true)
+  |            
   |            targets {
   |                register("api22") {
   |                    instrumentationParams = mapOf(
@@ -100,6 +103,9 @@ internal val groovyStubConfig = """
   |                "configuration": "functional",
   |                "override": "overrideInConfiguration"
   |            ]
+  |            
+  |            suppressFlaky.set(true)
+  |            suppressFailure.set(true)
   |
   |            targets {
   |                api22 {

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsTask.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsTask.kt
@@ -92,11 +92,9 @@ public abstract class InstrumentationTestsTask @Inject constructor(
     public abstract val experiments: Property<Experiments>
 
     @get:Input
-    @get:Optional
     public abstract val suppressFailure: Property<Boolean>
 
     @get:Input
-    @get:Optional
     public abstract val suppressFlaky: Property<Boolean>
 
     @get:Input
@@ -196,8 +194,8 @@ public abstract class InstrumentationTestsTask @Inject constructor(
             },
             deviceDebug = enableDeviceDebug.get(),
             projectName = projectName.get(),
-            suppressFailure = suppressFailure.getOrElse(false),
-            suppressFlaky = suppressFlaky.getOrElse(false),
+            suppressFailure = suppressFailure.get(),
+            suppressFlaky = suppressFlaky.get(),
             impactAnalysisResult = ImpactAnalysisResult.create(
                 runOnlyChangedTests = runOnlyChangedTests.get(),
                 changedTestsFile = changedTests.asFile.orNull

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/configuration/InstrumentationConfiguration.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/configuration/InstrumentationConfiguration.kt
@@ -3,9 +3,16 @@ package com.avito.instrumentation.configuration
 import com.avito.instrumentation.configuration.target.TargetConfiguration
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.property
 import java.time.Duration
+import javax.inject.Inject
 
-public abstract class InstrumentationConfiguration(public val name: String) {
+public abstract class InstrumentationConfiguration @Inject constructor(
+    public val name: String,
+    private val objects: ObjectFactory
+) {
 
     internal abstract val targetsContainer: NamedDomainObjectContainer<TargetConfiguration>
 
@@ -27,6 +34,18 @@ public abstract class InstrumentationConfiguration(public val name: String) {
     public var enableDeviceDebug: Boolean = false
 
     public var filter: String = "default"
+
+    /**
+     * failures of tests with @Flaky annotation will not impact run verdict
+     *
+     * https://avito-tech.github.io/avito-android/test/FlakyAnnotation/
+     */
+    public val suppressFlaky: Property<Boolean> = objects.property<Boolean>().convention(false)
+
+    /**
+     * any test failures will not impact run verdict
+     */
+    public val suppressFailure: Property<Boolean> = objects.property<Boolean>().convention(false)
 
     public fun targets(action: Action<NamedDomainObjectContainer<TargetConfiguration>>) {
         action.execute(targetsContainer)

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/AndroidVariantConfigurator.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/AndroidVariantConfigurator.kt
@@ -2,7 +2,4 @@ package com.avito.instrumentation.internal
 
 import com.android.build.api.variant.Variant
 
-internal interface AndroidVariantConfigurator<T : Variant> : InstrumentationTaskConfigurator {
-
-    val variant: T
-}
+internal abstract class AndroidVariantConfigurator<T : Variant>(val variant: T) : InstrumentationTaskConfigurator

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/ApplicationVariantConfigurator.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/ApplicationVariantConfigurator.kt
@@ -4,9 +4,8 @@ import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationVariant
 import com.avito.instrumentation.InstrumentationTestsTask
 
-internal class ApplicationVariantConfigurator(
-    override val variant: ApplicationVariant
-) : AndroidVariantConfigurator<ApplicationVariant> {
+internal class ApplicationVariantConfigurator(variant: ApplicationVariant) :
+    AndroidVariantConfigurator<ApplicationVariant>(variant) {
 
     override fun configure(task: InstrumentationTestsTask) {
         val androidTestVariant = variant.androidTest

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/BuildEnvResolver.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/BuildEnvResolver.kt
@@ -1,15 +1,15 @@
 package com.avito.instrumentation.internal
 
-import com.avito.utils.gradle.envArgs
-import org.gradle.api.Project
+import com.avito.utils.gradle.EnvArgs
+import org.gradle.api.provider.Provider
 
-internal class BuildEnvResolver(private val project: Project) {
+internal class BuildEnvResolver(private val envArgs: Provider<EnvArgs>) {
 
     fun getBuildId(): String {
-        return project.envArgs.build.id.toString()
+        return envArgs.get().build.id.toString()
     }
 
     fun getBuildType(): String {
-        return project.envArgs.build.type
+        return envArgs.get().build.type
     }
 }

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/ConfiguratorsFactory.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/ConfiguratorsFactory.kt
@@ -1,11 +1,13 @@
 package com.avito.instrumentation.internal
 
 import com.android.build.api.variant.Variant
+import com.avito.git.gitState
 import com.avito.instrumentation.configuration.InstrumentationConfiguration
 import com.avito.instrumentation.configuration.InstrumentationTestsPluginExtension
 import com.avito.logger.LoggerFactory
 import com.avito.time.DefaultTimeProvider
 import com.avito.time.TimeProvider
+import com.avito.utils.gradle.envArgs
 import org.gradle.api.Project
 
 internal class ConfiguratorsFactory(
@@ -16,9 +18,10 @@ internal class ConfiguratorsFactory(
 
     private val timeProvider: TimeProvider = DefaultTimeProvider()
 
-    private val gitResolver = GitResolver(project)
+    private val gitResolver = GitResolver(project.gitState())
 
-    private val buildEnvResolver = BuildEnvResolver(project)
+    // todo envArgs should be lazy, see [com.avito.kotlin.dsl.ProjectProperty]
+    private val buildEnvResolver = BuildEnvResolver(project.provider { project.envArgs })
 
     private val runIdResolver = RunIdResolver(
         timeProvider = timeProvider,

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/GitResolver.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/GitResolver.kt
@@ -1,24 +1,15 @@
 package com.avito.instrumentation.internal
 
-import com.avito.git.gitState
-import org.gradle.api.Project
+import com.avito.git.GitState
 import org.gradle.api.provider.Provider
 
-internal class GitResolver(private val project: Project) {
+internal class GitResolver(private val gitState: Provider<GitState>) {
 
     fun getGitBranch(): Provider<String> {
-        return project.gitState().map { it.currentBranch.name }
+        return gitState.map { it.currentBranch.name }
     }
 
     fun getGitCommit(): Provider<String> {
-        return project.gitState().map { it.currentBranch.commit }
-    }
-
-    fun getTargetCommit(): Provider<String> {
-        return project.gitState().map { git ->
-            requireNotNull(git.targetBranch?.commit) {
-                "Target commit is required to find modified tests"
-            }
-        }
+        return gitState.map { it.currentBranch.commit }
     }
 }

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/InstrumentationConfigurator.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/InstrumentationConfigurator.kt
@@ -45,6 +45,9 @@ internal class InstrumentationConfigurator(
                 outputFolder = outputDir.get().asFile,
             )
         )
+
+        task.suppressFailure.set(configuration.suppressFailure)
+        task.suppressFlaky.set(configuration.suppressFlaky)
     }
 
     private fun getInstrumentationConfiguration(

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/LibraryVariantConfigurator.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/internal/LibraryVariantConfigurator.kt
@@ -4,9 +4,8 @@ import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.LibraryVariant
 import com.avito.instrumentation.InstrumentationTestsTask
 
-internal class LibraryVariantConfigurator(
-    override val variant: LibraryVariant
-) : AndroidVariantConfigurator<LibraryVariant> {
+internal class LibraryVariantConfigurator(variant: LibraryVariant) :
+    AndroidVariantConfigurator<LibraryVariant>(variant) {
 
     override fun configure(task: InstrumentationTestsTask) {
         val androidTestVariant = variant.androidTest


### PR DESCRIPTION
suppressFlaky/suppressFailure was only configurable via CiStep: UiTestsStep;
With umbrella tasks we need this properties available on configuration level