### PR TITLE
MBS-12056 [Instrumentation plugin] support flavors

### DIFF
--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/TestSummaryPluginBuildStep.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/TestSummaryPluginBuildStep.kt
@@ -42,7 +42,8 @@ public abstract class TestSummaryPluginBuildStep(context: String, name: String) 
 
         if (useImpactAnalysis && !project.internalModule.isModified()) return
 
-        val instrumentationTask = project.tasks.instrumentationTask(configuration)
+        // flavors not supported here
+        val instrumentationTask = project.tasks.instrumentationTask(configuration, null)
 
         val reportCoordinates = instrumentationTask.extractReportCoordinates()
 

--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/UiTestCheck.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/UiTestCheck.kt
@@ -30,7 +30,8 @@ public open class UiTestCheck(context: String, name: String) : SuppressibleBuild
 
             configurations.forEach { configuration ->
 
-                val uiTestTask = project.tasks.instrumentationTask(configuration)
+                // flavors not supported here
+                val uiTestTask = project.tasks.instrumentationTask(configuration, null)
 
                 // it is safe to call get() here because task instrumentationXXX must be ready here
                 // can't configure task in registration of another

--- a/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/UploadBuildResult.kt
+++ b/subprojects/gradle/cd/src/main/kotlin/com/avito/ci/steps/UploadBuildResult.kt
@@ -35,7 +35,8 @@ public class UploadBuildResult(context: String, name: String) : SuppressibleBuil
                 "uploadBuildResult.uiTestConfiguration parameter must be set"
             }
 
-            val instrumentationTask = project.tasks.instrumentationTask(uiTestConfiguration)
+            // flavors not supported here
+            val instrumentationTask = project.tasks.instrumentationTask(uiTestConfiguration, null)
 
             val reportCoordinates = instrumentationTask.extractReportCoordinates().get()
             val reportViewerUrl = instrumentationTask.extractReportViewerUrl().get()

--- a/subprojects/test-runner/instrumentation-tests/src/gradleTest/kotlin/com/avito/instrumentation/InstrumentationTestsPluginTest.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/gradleTest/kotlin/com/avito/instrumentation/InstrumentationTestsPluginTest.kt
@@ -98,6 +98,100 @@ internal class InstrumentationTestsPluginTest {
     }
 
     @Test
+    fun `run instrumentation by name - ok - in application project with flavors`(@TempDir projectDir: File) {
+        val moduleName = "app"
+
+        createProject(
+            projectDir = projectDir,
+            module = AndroidAppModule(
+                moduleName,
+                plugins = plugins {
+                    id(instrumentationPluginId)
+                },
+                buildGradleExtra = """
+                    |${instrumentationConfiguration()}
+                    |    
+                    |android {
+                    |   flavorDimensions "version"
+                    |    productFlavors {
+                    |       demo { 
+                    |           dimension "version"
+                    |       }
+                    |       full {
+                    |           dimension "version"
+                    |       }
+                    |    }
+                    |}
+                    |""".trimMargin()
+            )
+        )
+
+        runGradle(
+            projectDir,
+            ":$moduleName:instrumentationDemoTwo",
+            ":$moduleName:instrumentationFullTwo",
+            "-PrunOnlyFailedTests=false"
+        ).assertThat()
+            .run {
+                tasksShouldBeTriggered(
+                    ":$moduleName:instrumentationDemoTwo",
+                    ":$moduleName:instrumentationFullTwo"
+                ).inOrder()
+            }
+    }
+
+    @Test
+    fun `run instrumentation by name - ok - in application project with multidimensional flavors`(
+        @TempDir projectDir: File
+    ) {
+        val moduleName = "app"
+
+        createProject(
+            projectDir = projectDir,
+            module = AndroidAppModule(
+                moduleName,
+                plugins = plugins {
+                    id(instrumentationPluginId)
+                },
+                buildGradleExtra = """
+                    |${instrumentationConfiguration()}
+                    |    
+                    |android {
+                    |   flavorDimensions "version", "monetization"
+                    |    productFlavors {
+                    |       demo { 
+                    |           dimension "version"
+                    |       }
+                    |       full {
+                    |           dimension "version"
+                    |       }
+                    |       free {
+                    |           dimension "monetization"
+                    |       }
+                    |       paid {
+                    |           dimension "monetization"
+                    |       }
+                    |    }
+                    |}
+                    |""".trimMargin()
+            )
+        )
+
+        runGradle(
+            projectDir,
+            ":$moduleName:instrumentationDemoFreeTwo",
+            ":$moduleName:instrumentationFullPaidTwo",
+            "-PrunOnlyFailedTests=false"
+        ).assertThat()
+            .run {
+                tasksShouldBeTriggered(
+                    ":$moduleName:instrumentationDemoFreeTwo",
+                    ":$moduleName:instrumentationFullPaidTwo"
+                ).inOrder()
+            }
+    }
+
+    @Test
     fun `run instrumentation by name - ok - in library project`(@TempDir projectDir: File) {
         val moduleName = "lib"
 

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsPlugin.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsPlugin.kt
@@ -46,14 +46,13 @@ public class InstrumentationTestsPlugin : Plugin<Project> {
             extension.configurationsContainer.all { configuration ->
 
                 // todo how to write "only testBuildType" selector?
-                // todo support flavors
                 androidComponents.onVariants { variant ->
 
                     val configurators = factory.createTaskConfigurators(configuration, variant)
 
                     if (configurators != null) {
                         project.tasks.register(
-                            instrumentationTaskName(configuration.name),
+                            instrumentationTaskName(configuration.name, variant.flavorName),
                             configureInstrumentationTask(
                                 configurators = configurators,
                                 configuration = configuration,

--- a/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsPluginApi.kt
+++ b/subprojects/test-runner/instrumentation-tests/src/main/kotlin/com/avito/instrumentation/InstrumentationTestsPluginApi.kt
@@ -7,14 +7,23 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 
-internal fun instrumentationTaskName(configuration: String): String =
-    "instrumentation${configuration.capitalize()}"
+internal fun instrumentationTaskName(configuration: String, flavor: String?): String {
+    return buildString {
+        append("instrumentation")
+        if (!flavor.isNullOrBlank()) {
+            append(flavor.capitalize())
+        }
+        append(configuration.capitalize())
+    }
+}
 
 /**
  * Available only afterEvaluate MBS-6926
  */
-public fun TaskContainer.instrumentationTask(configuration: String): TaskProvider<InstrumentationTestsTask> =
-    typedNamed(instrumentationTaskName(configuration))
+public fun TaskContainer.instrumentationTask(
+    configuration: String,
+    flavor: String?
+): TaskProvider<InstrumentationTestsTask> = typedNamed(instrumentationTaskName(configuration, flavor))
 
 public fun TaskProvider<InstrumentationTestsTask>.extractReportCoordinates(): Provider<ReportCoordinates> =
     flatMap { task ->


### PR DESCRIPTION
plugin will produce tasks with flavors if present:
for example: `instrumentationDemoUi`, where `demo` - flavor name and `ui` - instrumentation configuration

afaik tests can be run for only one buildType, specified by `testBuildType` property, so no need to use variants here

multidimensional flavors also supported, but i'm not sure how to handle which dimension goes first, so i create tasks for all combinations

cc @materkey