### PR TITLE
MBS-12272 fix incorrect task dependencies warnings check spam

### DIFF
--- a/build-logic/gradle-ext/src/main/kotlin/com/avito/android/Inconsistency.kt
+++ b/build-logic/gradle-ext/src/main/kotlin/com/avito/android/Inconsistency.kt
@@ -1,6 +1,6 @@
 package com.avito.android
 
 internal data class Inconsistency(
-    val projectPath: String,
+    val file: String,
     val reason: String
 )

--- a/build-logic/gradle-ext/src/main/kotlin/convention.gradle-properties.gradle.kts
+++ b/build-logic/gradle-ext/src/main/kotlin/convention.gradle-properties.gradle.kts
@@ -25,5 +25,5 @@ tasks.register<CheckCommonProperties>("checkCommonProperties") {
     description = "Checks consistency for common gradle.properties for all included builds"
 
     commonPropertiesFile.set(commonPropertiesFileProvider)
-    projectDirs.set(allProjectDirsProvider)
+    gradlePropertiesFiles.set(allProjectDirsProvider.map { it.map { it.file("gradle.properties") } })
 }

--- a/build-logic/gradle-ext/src/main/kotlin/convention.gradle-wrapper.gradle.kts
+++ b/build-logic/gradle-ext/src/main/kotlin/convention.gradle-wrapper.gradle.kts
@@ -19,7 +19,8 @@ val includedProjectDirs = provider {
         .map { project.resolveDir(it) }
 }
 
-val allProjectDirsProvider: Provider<List<Directory>> = includedProjectDirs.map { it + layout.projectDirectory }
+val allProjectsWrapperProperties: Provider<List<RegularFile>> = includedProjectDirs.map { it + layout.projectDirectory }
+    .map { it.map { it.file("gradle/wrapper/gradle-wrapper.properties") } }
 
 val gradleVer = "7.2"
 val distribution = Wrapper.DistributionType.BIN
@@ -41,7 +42,7 @@ tasks.register<CheckWrapper>("checkGradleWrappers") {
 
     expectedGradleVersion.set(gradleVer)
     expectedDistributionType.set(distribution)
-    projectDirs.set(allProjectDirsProvider)
+    wrapperPropertiesFiles.set(allProjectsWrapperProperties)
 }
 
 fun makeProjectNameSuitableForTaskNameSlug(projectName: String): String {


### PR DESCRIPTION
was reproducible with running `./gradlew checkAll`
problem was that outputDirectories of CheckWrapper and CheckCommonProperties tasks was implicitly used as inputs for gradleTest tasks

see https://docs.gradle.org/7.2/userguide/validation_problems.html#implicit_dependency