### PR TITLE
MBS-12172 uiDevice lazy initialization

### DIFF
--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/Device.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/Device.kt
@@ -34,7 +34,7 @@ import org.junit.Assert.assertTrue
  */
 object Device {
 
-    private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    private val uiDevice by lazy { UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()) }
 
     val keyboard = KeyboardElement()
 


### PR DESCRIPTION
Robolectric tests throw

```kotlin
Caused by: java.lang.NullPointerException
	at androidx.test.uiautomator.QueryController.<init>(QueryController.java:95)
	at androidx.test.uiautomator.UiDevice.<init>(UiDevice.java:109)
	at androidx.test.uiautomator.UiDevice.getInstance(UiDevice.java:261)
	at com.avito.android.test.Device.<clinit>(Device.kt:37)
```
when calling `rotate` or `pressBack`
