### PR TITLE
Remove deployments when they are not needed

### DIFF
--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/TestRunnerFactoryProvider.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/TestRunnerFactoryProvider.kt
@@ -12,8 +12,10 @@ import com.avito.runner.scheduler.metrics.TestRunnerMetricsListener
 import com.avito.runner.scheduler.metrics.TestRunnerMetricsSenderImpl
 import com.avito.runner.scheduler.runner.TestRunnerExecutionState
 import com.avito.runner.scheduler.runner.model.TestRunRequestFactory
+import com.avito.runner.service.worker.device.Device
 import com.avito.runner.service.worker.device.adb.listener.RunnerMetricsConfig
 import com.avito.time.TimeProvider
+import kotlinx.coroutines.channels.Channel
 import java.io.File
 import java.nio.file.Files
 
@@ -24,12 +26,13 @@ public class TestRunnerFactoryProvider(
     private val report: Report,
     private val devicesProviderFactory: DevicesProviderFactory,
     private val loggerFactory: LoggerFactory,
+    private val deviceSignals: Channel<Device.Signal>,
     metricsConfig: RunnerMetricsConfig,
 ) {
 
     private val outputDir = params.outputDir
     private val tempLogcatDir = Files.createTempDirectory(null).toFile()
-    private val testRunnerExecutionState = TestRunnerExecutionState()
+    private val testRunnerExecutionState = TestRunnerExecutionState(deviceSignals = deviceSignals)
 
     private val statsDSender: StatsDSender = StatsDSender.create(
         config = metricsConfig.statsDConfig,

--- a/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/scheduler/TestSchedulerFactoryProvider.kt
+++ b/subprojects/test-runner/client/src/main/kotlin/com/avito/runner/scheduler/runner/scheduler/TestSchedulerFactoryProvider.kt
@@ -21,10 +21,12 @@ import com.avito.runner.scheduler.report.ReportFactoryImpl
 import com.avito.runner.scheduler.suite.TestSuiteProvider
 import com.avito.runner.scheduler.suite.filter.FilterFactory
 import com.avito.runner.scheduler.suite.filter.FilterInfoWriter
+import com.avito.runner.service.worker.device.Device
 import com.avito.runner.service.worker.device.adb.listener.RunnerMetricsConfig
 import com.avito.time.DefaultTimeProvider
 import com.avito.time.TimeProvider
 import com.avito.utils.ProcessRunner
+import kotlinx.coroutines.channels.Channel
 
 public class TestSchedulerFactoryProvider(private val loggerFactory: LoggerFactory) {
 
@@ -58,6 +60,7 @@ public class TestSchedulerFactoryProvider(private val loggerFactory: LoggerFacto
             outputDir = params.outputDir
         )
 
+        val deviceSignals: Channel<Device.Signal> = Channel(Channel.UNLIMITED)
         return TestSchedulerFactoryImpl(
             finalizerFactory = FinalizerFactoryImpl(
                 report = report,
@@ -117,13 +120,15 @@ public class TestSchedulerFactoryProvider(private val loggerFactory: LoggerFacto
                             runnerMetricsConfig = metricsConfig,
                             loggerFactory = loggerFactory,
                             sendPodsMetrics = params.sendPodsMetrics,
-                        )
+                        ),
+                        deviceSignals = deviceSignals,
                     ),
                     androidDebugBridgeProvider = androidDebugBridgeProvider,
                     emulatorsLogsReporterProvider = emulatorsLogsReporterProvider,
                     metricsConfig = metricsConfig
                 ).provide(),
-                metricsConfig = metricsConfig
+                metricsConfig = metricsConfig,
+                deviceSignals = deviceSignals,
             ),
             testSuiteLoader = TestSuiteLoader.create(),
             loggerFactory = loggerFactory,

--- a/subprojects/test-runner/device-provider/api/src/main/kotlin/com/avito/runner/reservation/DeviceReservation.kt
+++ b/subprojects/test-runner/device-provider/api/src/main/kotlin/com/avito/runner/reservation/DeviceReservation.kt
@@ -5,4 +5,5 @@ import com.avito.runner.service.worker.device.DeviceCoordinate
 public interface DeviceReservation {
 
     public suspend fun releaseDevice(coordinate: DeviceCoordinate)
+    public suspend fun releaseReservation(name: String)
 }

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/FakeDevicesProvider.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/FakeDevicesProvider.kt
@@ -55,6 +55,9 @@ internal class FakeDevicesProvider(
         // empty
     }
 
+    override suspend fun releaseReservation(name: String) {
+    }
+
     override suspend fun releaseDevices() {
         devices.close()
     }

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/KubernetesDevicesProvider.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/KubernetesDevicesProvider.kt
@@ -56,6 +56,10 @@ internal class KubernetesDevicesProvider(
         client.remove(coordinate.podName)
     }
 
+    override suspend fun releaseReservation(name: String) {
+        client.removeDeployment(name)
+    }
+
     override suspend fun releaseDevices() {
         client.release()
     }

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/LocalDevicesProvider.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/LocalDevicesProvider.kt
@@ -80,6 +80,9 @@ internal class LocalDevicesProvider(
         // empty
     }
 
+    override suspend fun releaseReservation(name: String) {
+    }
+
     private fun findDevices(
         reservation: ReservationData,
         acquiredDevices: Set<DeviceCoordinate>

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/ReservationClient.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/ReservationClient.kt
@@ -16,5 +16,7 @@ internal interface ReservationClient {
         podName: String
     )
 
+    suspend fun removeDeployment(name: String)
+
     suspend fun release()
 }

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClient.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClient.kt
@@ -74,6 +74,10 @@ internal class KubernetesReservationClient(
         }
     }
 
+    override suspend fun removeDeployment(name: String) {
+        reservationReleaser.releaseDeployment(name)
+    }
+
     override suspend fun release() = withContext(dispatcher) {
         lock.withLock {
             val state = state

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClientFactory.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClientFactory.kt
@@ -3,8 +3,10 @@ package com.avito.android.runner.devices.internal.kubernetes
 import com.avito.android.runner.devices.internal.EmulatorsLogsReporter
 import com.avito.k8s.KubernetesApi
 import com.avito.logger.LoggerFactory
+import com.avito.runner.service.worker.device.Device
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
 
 @ExperimentalCoroutinesApi
@@ -16,7 +18,8 @@ internal class KubernetesReservationClientFactory(
     private val listener: KubernetesReservationListener,
     private val loggerFactory: LoggerFactory,
     private val podsQueryIntervalMs: Long,
-    private val dispatcher: CoroutineDispatcher
+    private val dispatcher: CoroutineDispatcher,
+    private val deviceSignals: Channel<Device.Signal>
 ) {
 
     fun create(): KubernetesReservationClient {
@@ -41,7 +44,8 @@ internal class KubernetesReservationClientFactory(
             emulatorsLogsReporter,
             listener,
             lock,
-            loggerFactory
+            loggerFactory,
+            deviceSignals = deviceSignals,
         )
 
     private fun releaser(): KubernetesReservationReleaser =

--- a/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClientProvider.kt
+++ b/subprojects/test-runner/device-provider/impl/src/main/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClientProvider.kt
@@ -4,8 +4,10 @@ import com.avito.android.runner.devices.internal.AndroidDebugBridgeProvider
 import com.avito.android.runner.devices.internal.EmulatorsLogsReporterProvider
 import com.avito.k8s.KubernetesApiFactory
 import com.avito.logger.LoggerFactory
+import com.avito.runner.service.worker.device.Device
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import java.io.File
 
 public class KubernetesReservationClientProvider(
@@ -14,7 +16,8 @@ public class KubernetesReservationClientProvider(
     private val reservationDeploymentFactoryProvider: ReservationDeploymentFactoryProvider,
     private val emulatorsLogsReporterProvider: EmulatorsLogsReporterProvider,
     private val androidDebugBridgeProvider: AndroidDebugBridgeProvider,
-    private val kubernetesReservationListenerProvider: KubernetesReservationListenerProvider
+    private val kubernetesReservationListenerProvider: KubernetesReservationListenerProvider,
+    private val deviceSignals: Channel<Device.Signal>,
 ) {
 
     @ExperimentalCoroutinesApi
@@ -36,7 +39,8 @@ public class KubernetesReservationClientProvider(
             listener = kubernetesReservationListenerProvider.provide(),
             loggerFactory = loggerFactory,
             podsQueryIntervalMs = 5000L,
-            dispatcher = Dispatchers.IO
+            dispatcher = Dispatchers.IO,
+            deviceSignals = deviceSignals,
         ).create()
     }
 }

--- a/subprojects/test-runner/device-provider/impl/src/test/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClientTest.kt
+++ b/subprojects/test-runner/device-provider/impl/src/test/kotlin/com/avito/android/runner/devices/internal/kubernetes/KubernetesReservationClientTest.kt
@@ -10,10 +10,12 @@ import com.avito.k8s.StubKubernetesApi
 import com.avito.k8s.model.KubePod
 import com.avito.k8s.model.createStubInstance
 import com.avito.logger.PrintlnLoggerFactory
+import com.avito.runner.service.worker.device.Device
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -36,6 +38,7 @@ internal class KubernetesReservationClientTest {
     private fun runBlockingTest(block: suspend TestCoroutineScope.() -> Unit) {
         dispatcher.runBlockingTest(block)
     }
+    private val deviceSignals: Channel<Device.Signal> = Channel(Channel.UNLIMITED)
 
     private fun client(
         dispatcher: CoroutineDispatcher = this.dispatcher,
@@ -53,7 +56,8 @@ internal class KubernetesReservationClientTest {
             reservationDeploymentFactory = FakeReservationDeploymentFactory(),
             dispatcher = dispatcher,
             podsQueryIntervalMs = podsQueryInterval,
-            listener = StubKubernetesReservationListener
+            listener = StubKubernetesReservationListener,
+            deviceSignals = deviceSignals,
         ).create()
     }
 

--- a/subprojects/test-runner/service/src/main/kotlin/com/avito/runner/service/worker/device/Device.kt
+++ b/subprojects/test-runner/service/src/main/kotlin/com/avito/runner/service/worker/device/Device.kt
@@ -13,6 +13,8 @@ public interface Device {
 
     public sealed class Signal {
         public data class Died(val coordinate: DeviceCoordinate) : Signal()
+        public data class ReservationNotNeeded(val deviceName: String) : Signal()
+        public data class NewDeployment(val deploymentName: String, val deviceName: String) : Signal()
     }
 
     public val coordinate: DeviceCoordinate


### PR DESCRIPTION
Example:
1st deployment is [redroid](https://github.com/remote-android/redroid-doc)
2nd deployment is QEMU emulators for GPS, camera, google services, etc.

Expected:
When tests for one of the deployments finished I want the deployment to be destroyed 

Actual:
They are idling until end