### PR TITLE
MBSA-636 Publish CdBuildConfig from Nupokati plugin

### DIFF
--- a/subprojects/delivery/nupokati/src/main/kotlin/com/avito/android/NupokatiPlugin.kt
+++ b/subprojects/delivery/nupokati/src/main/kotlin/com/avito/android/NupokatiPlugin.kt
@@ -25,18 +25,20 @@ import org.gradle.kotlin.dsl.withType
 
 public class NupokatiPlugin : Plugin<Project> {
 
+    public lateinit var cdBuildConfig: Provider<CdBuildConfig>
+
     override fun apply(project: Project) {
 
         val extension = project.extensions.create<NupokatiExtension>("nupokati")
+
+        cdBuildConfig = extension.cdBuildConfigFile
+            .map(CdBuildConfigTransformer(validator = StrictCdBuildConfigValidator()))
 
         project.plugins.withType<AppPlugin> {
             val androidComponents = project.extensions.getByType<ApplicationAndroidComponentsExtension>()
 
             val releaseVariantSelector = androidComponents.selector()
                 .withName(extension.releaseBuildVariantName.convention(DEFAULT_RELEASE_VARIANT).get())
-
-            val cdBuildConfig: Provider<CdBuildConfig> = extension.cdBuildConfigFile
-                .map(CdBuildConfigTransformer(validator = StrictCdBuildConfigValidator()))
 
             val skipUploadSpec = Spec<Task> {
                 val skipUpload = cdBuildConfig.get().outputDescriptor.skipUpload
@@ -83,7 +85,7 @@ public class NupokatiPlugin : Plugin<Project> {
                     this.reportViewerUrl.set(extension.reportViewer.frontendUrl)
                     this.reportCoordinates.set(extension.reportViewer.reportCoordinates)
                     this.teamcityBuildUrl.set(extension.teamcityBuildUrl)
-                    this.cdBuildConfig.set(cdBuildConfig)
+                    this.cdBuildConfig.set(this@NupokatiPlugin.cdBuildConfig)
                     this.appVersionCode.set(variant.getVersionCode())
                     this.buildOutputFileProperty.set(publishArtifactsTask.flatMap { it.buildOutput })
                     this.statsDConfig.set(project.statsdConfig)


### PR DESCRIPTION
Previously, clients used `Project.cdBuildConfig` to get a config. It was from legacy `upload-cd-build-result` module.

Not, the path to config is configured in nupokati plugin. 
Clients still need to read it to configure other tasks (e.g. qapps) and applications (e.g. version name).