### PR TITLE
Mbsa 648 Add client defined prefix to JVM metrics

### DIFF
--- a/docs/content/projects/internal/BuildMetrics.md
+++ b/docs/content/projects/internal/BuildMetrics.md
@@ -8,6 +8,12 @@
 
 ## Configuring
 
+```kotlin
+buildMetrics {
+    metricsPrefix.addAll("prefix") // optional
+}
+```
+
 ### Disabling plugin
 
 Project property `avito.build.metrics.enabled=false`
@@ -17,11 +23,17 @@ Project property `avito.build.metrics.enabled=false`
 All metrics can use common placeholders in prefix:
 
 - Namespace: statsd prefix from `avito.stats.namespace` property
+- Prefix: from `metricsPrefix` property
+
+There are also deprecated ones:
+
 - Environment: `ci` | `local` | `_` (unknown)
 - Node: git username for local builds, hostname for CI builds
 - Build status: `success` | `failure`
 
-They will be referred in docs as `<placeholder>`.
+They will be replaced in favor of `metricsPrefix`.
+
+All mentioned prefixes will be referred in docs as `<...>`.
 
 ### Build cache metrics
 
@@ -81,7 +93,7 @@ To understand the critical path better see a visualization in a [build trace](..
 
 ### JVM metrics
 
-`<namespace>.<environment>.<node>.jvm.memory.<jvm process name>.[heap|metaspace].[used|committed]`
+`<namespace>.[<prefix>].jvm.memory.<jvm process name>.[heap|metaspace].[used|committed]`
 
 This reflects what you can find by [jcmd PID GC.heap_info](https://www.baeldung.com/java-heap-size-cli#jcmd).  
 All values are measured in Kb and sent as time metrics.

--- a/subprojects/assemble/build-metrics-tracker/src/main/kotlin/com/avito/android/build_metrics/BuildMetricTracker.kt
+++ b/subprojects/assemble/build-metrics-tracker/src/main/kotlin/com/avito/android/build_metrics/BuildMetricTracker.kt
@@ -13,7 +13,6 @@ import com.avito.android.stats.statsd
 import com.avito.utils.gradle.Environment
 import org.gradle.api.Project
 
-// TODO: Use statsd client directly and pass required prefix from client/plugin
 public interface BuildMetricTracker {
 
     public fun track(status: BuildStatus, metric: StatsMetric)

--- a/subprojects/assemble/build-metrics-tracker/src/main/kotlin/com/avito/android/build_metrics/BuildMetricTracker.kt
+++ b/subprojects/assemble/build-metrics-tracker/src/main/kotlin/com/avito/android/build_metrics/BuildMetricTracker.kt
@@ -13,7 +13,9 @@ import com.avito.android.stats.statsd
 import com.avito.utils.gradle.Environment
 import org.gradle.api.Project
 
+// TODO: Use statsd client directly and pass required prefix from client/plugin
 public interface BuildMetricTracker {
+
     public fun track(status: BuildStatus, metric: StatsMetric)
     public fun track(metric: StatsMetric)
 

--- a/subprojects/assemble/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/jvm/JvmMetricsTest.kt
+++ b/subprojects/assemble/build-metrics/src/gradleTest/kotlin/com/avito/android/plugin/build_metrics/jvm/JvmMetricsTest.kt
@@ -27,6 +27,9 @@ internal class JvmMetricsTest {
                 id("com.avito.android.build-metrics")
             },
             buildGradleExtra = """
+                buildMetrics {
+                    metricsPrefix.addAll("build_id")
+                }
                 tasks.register<Task>("delay") {
                     doLast {
                         Thread.sleep(3000)
@@ -48,17 +51,17 @@ internal class JvmMetricsTest {
 
         val atLeastOne: IterableSubject.() -> Unit = { isNotEmpty() }
 
-        result.assertHasMetric<TimeMetric>(".jvm.memory.gradle_daemon.heap.used", atLeastOne)
-        result.assertHasMetric<TimeMetric>(".jvm.memory.gradle_daemon.heap.committed", atLeastOne)
+        result.assertHasMetric<TimeMetric>(".build_id.jvm.memory.gradle_daemon.heap.used", atLeastOne)
+        result.assertHasMetric<TimeMetric>(".build_id.jvm.memory.gradle_daemon.heap.committed", atLeastOne)
 
-        result.assertHasMetric<TimeMetric>(".jvm.memory.gradle_daemon.metaspace.used", atLeastOne)
-        result.assertHasMetric<TimeMetric>(".jvm.memory.gradle_daemon.metaspace.committed", atLeastOne)
+        result.assertHasMetric<TimeMetric>(".build_id.jvm.memory.gradle_daemon.metaspace.used", atLeastOne)
+        result.assertHasMetric<TimeMetric>(".build_id.jvm.memory.gradle_daemon.metaspace.committed", atLeastOne)
 
-        result.assertHasMetric<TimeMetric>(".jvm.memory.gradle_worker.heap.used", atLeastOne)
-        result.assertHasMetric<TimeMetric>(".jvm.memory.gradle_worker.heap.committed", atLeastOne)
+        result.assertHasMetric<TimeMetric>(".build_id.jvm.memory.gradle_worker.heap.used", atLeastOne)
+        result.assertHasMetric<TimeMetric>(".build_id.jvm.memory.gradle_worker.heap.committed", atLeastOne)
 
-        result.assertHasMetric<TimeMetric>(".jvm.memory.gradle_worker.metaspace.used", atLeastOne)
-        result.assertHasMetric<TimeMetric>(".jvm.memory.gradle_worker.metaspace.committed", atLeastOne)
+        result.assertHasMetric<TimeMetric>(".build_id.jvm.memory.gradle_worker.metaspace.used", atLeastOne)
+        result.assertHasMetric<TimeMetric>(".build_id.jvm.memory.gradle_worker.metaspace.committed", atLeastOne)
     }
 
     private fun build(vararg args: String) =

--- a/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsExtension.kt
+++ b/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsExtension.kt
@@ -1,0 +1,11 @@
+package com.avito.android.plugin.build_metrics
+
+import org.gradle.api.provider.ListProperty
+
+public abstract class BuildMetricsExtension {
+
+    /**
+     * Common prefix for statsd metrics
+     */
+    public abstract val metricsPrefix: ListProperty<String>
+}

--- a/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
+++ b/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/BuildMetricsPlugin.kt
@@ -18,12 +18,17 @@ import com.avito.android.plugin.build_metrics.internal.jvm.command.Jcmd
 import com.avito.android.plugin.build_metrics.internal.jvm.command.Jps
 import com.avito.android.plugin.build_metrics.internal.tasks.CriticalPathMetricsTracker
 import com.avito.android.plugin.build_metrics.internal.teamcity.CollectTeamcityMetricsTask
+import com.avito.android.stats.SeriesName
+import com.avito.android.stats.StatsDSender
+import com.avito.android.stats.statsd
+import com.avito.android.stats.withPrefix
 import com.avito.kotlin.dsl.getOptionalStringProperty
 import com.avito.kotlin.dsl.isRoot
 import com.avito.teamcity.teamcityCredentials
 import com.avito.utils.ProcessRunner
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.register
 
 public open class BuildMetricsPlugin : Plugin<Project> {
@@ -32,6 +37,8 @@ public open class BuildMetricsPlugin : Plugin<Project> {
         check(project.isRoot()) {
             "Plugin must be applied to the root project but was applied to ${project.path}"
         }
+
+        val extension = project.extensions.create<BuildMetricsExtension>("buildMetrics")
 
         if (!project.pluginIsEnabled) {
             project.logger.lifecycle("Build metrics plugin is disabled")
@@ -43,12 +50,24 @@ public open class BuildMetricsPlugin : Plugin<Project> {
             this.teamcityCredentials.set(project.teamcityCredentials)
             this.graphiteConfig.set(project.graphiteConfig)
         }
+        project.afterEvaluate { // values from extension are not available earlier
+            registerListeners(project, extension)
+        }
+    }
 
-        val buildMetricTracker = BuildMetricTracker.from(project)
+    private fun registerListeners(project: Project, extension: BuildMetricsExtension) {
+        // TODO: remove after migrating clients to an extension MBSA-648
+        val legacyMetricsTracker = BuildMetricTracker.from(project)
+        val metricsTracker: StatsDSender? = if (extension.metricsPrefix.isPresent) {
+            val prefix = SeriesName.create(*extension.metricsPrefix.get().toTypedArray())
+            project.statsd.get().withPrefix(prefix)
+        } else {
+            null
+        }
 
-        val buildOperationsListener = BuildOperationsResultProvider.register(project, buildMetricTracker)
+        val buildOperationsListener = BuildOperationsResultProvider.register(project, legacyMetricsTracker)
 
-        val criticalPathTracker = CriticalPathMetricsTracker(buildMetricTracker)
+        val criticalPathTracker = CriticalPathMetricsTracker(legacyMetricsTracker)
         CriticalPathRegistry.addListener(project, criticalPathTracker)
 
         val processRunner = ProcessRunner.create(workingDirectory = null)
@@ -61,14 +80,14 @@ public open class BuildMetricsPlugin : Plugin<Project> {
                 ),
                 jcmd = Jcmd(processRunner, javaHome)
             ),
-            sender = JvmMetricsSender(buildMetricTracker)
+            sender = JvmMetricsSender(legacyMetricsTracker, metricsTracker)
         )
 
         val buildListeners = listOf(
             jvmMetricsListener,
-            ConfigurationTimeListener(buildMetricTracker),
-            TotalBuildTimeListener(buildMetricTracker),
-            AppBuildTimeListener.from(project, buildMetricTracker)
+            ConfigurationTimeListener(legacyMetricsTracker),
+            TotalBuildTimeListener(legacyMetricsTracker),
+            AppBuildTimeListener.from(project, legacyMetricsTracker)
         )
 
         val eventsListeners = listOf(

--- a/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/jvm/JvmMetricsSender.kt
+++ b/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/jvm/JvmMetricsSender.kt
@@ -6,15 +6,21 @@ import com.avito.android.plugin.build_metrics.internal.jvm.LocalVm.GradleWorker
 import com.avito.android.plugin.build_metrics.internal.jvm.LocalVm.KotlinDaemon
 import com.avito.android.plugin.build_metrics.internal.jvm.LocalVm.Unknown
 import com.avito.android.stats.SeriesName
+import com.avito.android.stats.StatsDSender
 import com.avito.android.stats.StatsMetric
 
 internal class JvmMetricsSender(
-    private val tracker: BuildMetricTracker
+    private val legacyTracker: BuildMetricTracker,
+    private val tracker: StatsDSender?
 ) {
 
     fun send(vm: LocalVm, heapInfo: HeapInfo) {
-        metrics(vm, heapInfo).forEach {
-            tracker.track(it)
+        metrics(vm, heapInfo).forEach { metric ->
+            if (tracker != null) {
+                tracker.send(metric)
+            } else {
+                legacyTracker.track(metric)
+            }
         }
     }
 

--- a/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/jvm/command/GCHeapInfoParser.kt
+++ b/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/jvm/command/GCHeapInfoParser.kt
@@ -1,6 +1,8 @@
-package com.avito.android.plugin.build_metrics.internal.jvm
+package com.avito.android.plugin.build_metrics.internal.jvm.command
 
 import com.avito.android.Result
+import com.avito.android.plugin.build_metrics.internal.jvm.HeapInfo
+import com.avito.android.plugin.build_metrics.internal.jvm.MemoryUsage
 
 internal object GCHeapInfoParser {
 

--- a/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/jvm/command/Jcmd.kt
+++ b/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/jvm/command/Jcmd.kt
@@ -1,7 +1,6 @@
 package com.avito.android.plugin.build_metrics.internal.jvm.command
 
 import com.avito.android.Result
-import com.avito.android.plugin.build_metrics.internal.jvm.GCHeapInfoParser
 import com.avito.android.plugin.build_metrics.internal.jvm.HeapInfo
 import com.avito.android.plugin.build_metrics.internal.jvm.JavaHome
 import com.avito.utils.ProcessRunner

--- a/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/teamcity/CollectTeamcityMetricsTask.kt
+++ b/subprojects/assemble/build-metrics/src/main/kotlin/com/avito/android/plugin/build_metrics/internal/teamcity/CollectTeamcityMetricsTask.kt
@@ -12,6 +12,8 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
 
+// TODO: convert to CLI app.
+//  It's no use to use Gradle for such tasks. They need to know nothing about a project.
 internal abstract class CollectTeamcityMetricsTask @Inject constructor(
     private val workerExecutor: WorkerExecutor
 ) : DefaultTask() {

--- a/subprojects/assemble/build-metrics/src/test/kotlin/com/avito/android/plugin/build_metrics/jvm/JvmMetricsSenderTest.kt
+++ b/subprojects/assemble/build-metrics/src/test/kotlin/com/avito/android/plugin/build_metrics/jvm/JvmMetricsSenderTest.kt
@@ -10,19 +10,20 @@ import com.avito.android.plugin.build_metrics.internal.jvm.LocalVm.KotlinDaemon
 import com.avito.android.plugin.build_metrics.internal.jvm.LocalVm.Unknown
 import com.avito.android.plugin.build_metrics.internal.jvm.MemoryUsage
 import com.avito.android.stats.SeriesName
+import com.avito.android.stats.StubStatsdSender
 import com.avito.android.stats.TimeMetric
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
 internal class JvmMetricsSenderTest {
 
-    private val tracker = StubBuildMetricTracker()
+    private val tracker = StubStatsdSender()
 
     @Test
     fun `send - Gradle daemon`() {
         send(GradleDaemon(id = 1))
 
-        val metric = tracker.trackedMetrics.first()
+        val metric = tracker.getSentMetrics().first()
         assertThat(metric.name.asAspect()).contains(".gradle_daemon.")
     }
 
@@ -30,7 +31,7 @@ internal class JvmMetricsSenderTest {
     fun `send - Kotlin daemon`() {
         send(KotlinDaemon(id = 1))
 
-        val metric = tracker.trackedMetrics.first()
+        val metric = tracker.getSentMetrics().first()
         assertThat(metric.name.asAspect()).contains(".kotlin_daemon.")
     }
 
@@ -38,7 +39,7 @@ internal class JvmMetricsSenderTest {
     fun `send - Gradle worker`() {
         send(GradleWorker(id = 1))
 
-        val metric = tracker.trackedMetrics.first()
+        val metric = tracker.getSentMetrics().first()
         assertThat(metric.name.asAspect()).contains(".gradle_worker.")
     }
 
@@ -46,7 +47,7 @@ internal class JvmMetricsSenderTest {
     fun `send - unknown JVM process`() {
         send(Unknown(id = 1, name = "app.Worker"))
 
-        val metric = tracker.trackedMetrics.first()
+        val metric = tracker.getSentMetrics().first()
         assertThat(metric.name.asAspect()).contains(".app_worker.")
     }
 
@@ -60,26 +61,26 @@ internal class JvmMetricsSenderTest {
             )
         )
 
-        assertThat(tracker.trackedMetrics).contains(
+        assertThat(tracker.getSentMetrics()).contains(
             TimeMetric(SeriesName.create("jvm.memory.gradle_daemon.heap.used", multipart = true), 100)
         )
-        assertThat(tracker.trackedMetrics).contains(
+        assertThat(tracker.getSentMetrics()).contains(
             TimeMetric(SeriesName.create("jvm.memory.gradle_daemon.heap.committed", multipart = true), 200)
         )
-        assertThat(tracker.trackedMetrics).contains(
+        assertThat(tracker.getSentMetrics()).contains(
             TimeMetric(SeriesName.create("jvm.memory.gradle_daemon.metaspace.used", multipart = true), 50)
         )
-        assertThat(tracker.trackedMetrics).contains(
+        assertThat(tracker.getSentMetrics()).contains(
             TimeMetric(SeriesName.create("jvm.memory.gradle_daemon.metaspace.committed", multipart = true), 60)
         )
-        assertThat(tracker.trackedMetrics).hasSize(4)
+        assertThat(tracker.getSentMetrics()).hasSize(4)
     }
 
     private fun send(
         vm: LocalVm,
         heapInfo: HeapInfo = stubHeapInfo()
     ) =
-        JvmMetricsSender(tracker).send(vm, heapInfo)
+        JvmMetricsSender(StubBuildMetricTracker(), tracker).send(vm, heapInfo)
 
     private fun stubHeapInfo() = HeapInfo(
         heap = MemoryUsage(usedKb = 1, committedKb = 1),

--- a/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSender.kt
+++ b/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSender.kt
@@ -16,3 +16,6 @@ public interface StatsDSender {
         }
     }
 }
+
+public fun StatsDSender.withPrefix(series: SeriesName): StatsDSender =
+    StatsDSenderWithPrefix(delegate = this, prefix = series)

--- a/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSenderWithPrefix.kt
+++ b/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsDSenderWithPrefix.kt
@@ -1,0 +1,13 @@
+package com.avito.android.stats
+
+internal class StatsDSenderWithPrefix(
+    private val delegate: StatsDSender,
+    private val prefix: SeriesName,
+) : StatsDSender {
+
+    override fun send(metric: StatsMetric) {
+        delegate.send(
+            metric.copy(metric.name.prefix(prefix), metric.value)
+        )
+    }
+}

--- a/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsMetric.kt
+++ b/subprojects/common/statsd/src/main/kotlin/com/avito/android/stats/StatsMetric.kt
@@ -4,9 +4,12 @@ package com.avito.android.stats
  * [Statsd metrics](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#statsd-metric-types)
  */
 public sealed class StatsMetric {
+
     public abstract val name: SeriesName
     public abstract val value: Any
     public abstract val type: String
+
+    public abstract fun copy(name: SeriesName, value: Any): StatsMetric
 
     public companion object {
         public fun time(name: SeriesName, ms: Long): TimeMetric = TimeMetric(name, ms)
@@ -26,6 +29,9 @@ public data class TimeMetric(
 ) : StatsMetric() {
     override val value: Long = timeInMs
     override val type: String = "time"
+
+    override fun copy(name: SeriesName, value: Any): TimeMetric =
+        TimeMetric(name, value as Long)
 }
 
 /**
@@ -37,6 +43,9 @@ public data class CountMetric(
 ) : StatsMetric() {
     override val value: Long = delta
     override val type: String = "count"
+
+    override fun copy(name: SeriesName, value: Any): CountMetric =
+        CountMetric(name, value as Long)
 }
 
 /**
@@ -48,6 +57,9 @@ public data class GaugeLongMetric(
 ) : StatsMetric() {
     override val value: Long = gauge
     override val type: String = "gauge"
+
+    override fun copy(name: SeriesName, value: Any): GaugeLongMetric =
+        GaugeLongMetric(name, value as Long)
 }
 
 /**
@@ -59,4 +71,7 @@ public data class GaugeDoubleMetric(
 ) : StatsMetric() {
     override val value: Double = gauge
     override val type: String = "gauge"
+
+    override fun copy(name: SeriesName, value: Any): GaugeDoubleMetric =
+        GaugeDoubleMetric(name, value as Double)
 }

--- a/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/BuildEnvironment.kt
+++ b/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/BuildEnvironment.kt
@@ -15,7 +15,6 @@ public sealed class BuildEnvironment(
 ) {
     public class Local(providers: ProviderFactory, reason: String) : BuildEnvironment(providers, reason)
     public class GradleTestKit(providers: ProviderFactory, reason: String) : BuildEnvironment(providers, reason)
-    public class Mirkale(providers: ProviderFactory, reason: String) : BuildEnvironment(providers, reason)
     public class IDE(providers: ProviderFactory, reason: String) : BuildEnvironment(providers, reason)
     public class CI(providers: ProviderFactory, reason: String) : BuildEnvironment(providers, reason)
 

--- a/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/EnvironmentInfo.kt
+++ b/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/EnvironmentInfo.kt
@@ -1,6 +1,5 @@
 package com.avito.android.sentry
 
-import com.avito.git.Git
 import com.avito.kotlin.dsl.lazyProperty
 import com.avito.utils.gradle.Environment
 import com.avito.utils.gradle.internal.EnvironmentInfoImpl
@@ -13,15 +12,11 @@ import org.gradle.api.provider.Provider
 public interface EnvironmentInfo { // TODO: merge with BuildEnvironment and EnvArgs
     public val node: String?
     public val environment: Environment
-    public fun teamcityBuildId(): String?
 }
 
 public fun Project.environmentInfo(): Provider<EnvironmentInfo> =
     lazyProperty("ENVIRONMENT_INFO_PROVIDER") { project ->
         project.providers.provider {
-            val git = Git.create(
-                rootDir = project.rootDir,
-            )
-            EnvironmentInfoImpl(project, lazy { git.config("user.email") })
+            EnvironmentInfoImpl(project)
         }
     }

--- a/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/internal/EnvironmentInfoImpl.kt
+++ b/subprojects/gradle/build-environment/src/main/kotlin/com/avito/utils/gradle/internal/EnvironmentInfoImpl.kt
@@ -1,8 +1,6 @@
 package com.avito.utils.gradle.internal
 
-import com.avito.android.Result
 import com.avito.android.sentry.EnvironmentInfo
-import com.avito.kotlin.dsl.getOptionalStringProperty
 import com.avito.utils.gradle.BuildEnvironment
 import com.avito.utils.gradle.Environment
 import com.avito.utils.gradle.buildEnvironment
@@ -10,24 +8,12 @@ import org.gradle.api.Project
 
 internal class EnvironmentInfoImpl(
     private val project: Project,
-    private val gitUserEmailProvider: Lazy<Result<String>>
 ) : EnvironmentInfo {
-
-    private val gitUserEmail: String? by lazy {
-        if (hasGit) {
-            gitUserEmailProvider.value.fold(
-                { email -> email.substringBefore('@') },
-                { _ -> null }
-            )
-        } else {
-            null
-        }
-    }
 
     override val node: String? by lazy {
         when (environment) {
-            is Environment.Local -> gitUserEmail ?: userName()
-            is Environment.CI -> teamcityAgentName()
+            is Environment.Local -> userName()
+            is Environment.CI -> "_"
             is Environment.Unknown -> "unknown"
         }
     }
@@ -36,24 +22,12 @@ internal class EnvironmentInfoImpl(
         val buildEnvironment = project.buildEnvironment
         when {
             // we want ci metrics even if "-Pci=false" in CI
-            userName() == "teamcity" || gitUserEmail == "teamcity" -> Environment.CI
+            userName() == "teamcity" -> Environment.CI
             buildEnvironment is BuildEnvironment.Local || buildEnvironment is BuildEnvironment.IDE -> Environment.Local
             buildEnvironment is BuildEnvironment.CI -> Environment.CI
             else -> Environment.Unknown
         }
     }
 
-    private val hasGit: Boolean = project.buildEnvironment !is BuildEnvironment.Mirkale
-
     private fun userName(): String? = System.getProperty("user.name")
-
-    private fun teamcityAgentName(): String? {
-        return System.getenv("TEAMCITY_AGENT_NAME")
-            ?: System.getProperty("TEAMCITY_AGENT_NAME", null)
-    }
-
-    // todo to one place
-    override fun teamcityBuildId(): String? {
-        return project.rootProject.getOptionalStringProperty("teamcityBuildId")
-    }
 }

--- a/subprojects/gradle/build-environment/src/testFixtures/kotlin/com/avito/android/sentry/StubEnvironmentInfo.kt
+++ b/subprojects/gradle/build-environment/src/testFixtures/kotlin/com/avito/android/sentry/StubEnvironmentInfo.kt
@@ -5,8 +5,4 @@ import com.avito.utils.gradle.Environment
 class StubEnvironmentInfo(
     override val node: String? = null,
     override val environment: Environment = Environment.CI,
-    val teamcityBuildId: String? = null,
-) : EnvironmentInfo {
-
-    override fun teamcityBuildId(): String? = teamcityBuildId
-}
+) : EnvironmentInfo


### PR DESCRIPTION
Move responsibility for prefix in metrics to client side. 
Now they decide how to describe a build.

```kotlin
val buildId = someCustomLogic()

buildMetrics {
    metricsPrefix.addAll(buildId)
}
```