### PR TITLE
MBSA-687 Add prefix to a Github release tag to fix ambiguity with a branch name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ draft_release:
 	$(call check_defined, version)
 	$(call check_defined, prev_version)
 	git fetch --all
-	gh release create $(version) \
+	gh release create v$(version) \
 		--draft \
 		--target $(version) \
 		--title $(version) \


### PR DESCRIPTION
Github forbids such ambiguity

Example: https://github.com/avito-tech/avito-android/releases/tag/v2022.14