### PR TITLE
Build emulator without access to Avito internals

### DIFF
--- a/ci/docker/android-emulator/non-hermetic/Dockerfile
+++ b/ci/docker/android-emulator/non-hermetic/Dockerfile
@@ -1,7 +1,5 @@
-ARG DOCKER_REGISTRY
-FROM ${DOCKER_REGISTRY}/android/ubuntu:20.04
+FROM ubuntu:20.04
 
-ARG ARTIFACTORY_URL
 ARG SDK_VERSION
 ARG EMULATOR_ARCH
 
@@ -41,7 +39,7 @@ ENV LANG=C.UTF-8 \
 # ----------------- Android SDK -----------------
 # https://developer.android.com/studio/index.html#command-tools
 # Additional info about directory structure: https://stackoverflow.com/a/61176718/981330
-ARG COMMANDLINE_TOOLS_URL=$ARTIFACTORY_URL/android-build-env/android_sdk/commandlinetools/commandlinetools-linux-8092744_latest.zip
+ARG COMMANDLINE_TOOLS_URL=https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
 ARG ANDROID_SDK_FILE_NAME=commandlinetools.zip
 
 RUN curl $COMMANDLINE_TOOLS_URL --progress-bar --location --output $ANDROID_SDK_FILE_NAME && \

--- a/ci/docker/build_non_hermetic_emulator.sh
+++ b/ci/docker/build_non_hermetic_emulator.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+if [[ "$#" -ne 2 ]]; then
+    echo "ERROR: Wrong number of arguments. Expected ones:
+    You should pass image name and api level to publish:
+    ./build_non_hermetic_emulator.sh <image-name> <API level>
+
+    Example:
+    ./build_non_hermetic_emulator.sh android/emulator 30
+    "
+    exit 1
+fi
+
+readonly BUILD_DIRECTORY=$(pwd)/android-emulator
+readonly IMAGE_NAME=$1
+readonly API=$2
+
+# todo should run from ./ci/docker now, remove this requirement
+# todo image-builder should be docker image as well
+pushd image-builder
+./gradlew run --args="buildEmulator \
+        --dockerfilePath 'non-hermetic/Dockerfile' \
+        --buildDir '$(pwd)/../android-emulator' \
+        --imageName '${IMAGE_NAME}' \
+        --api '${API}'"
+popd

--- a/ci/docker/image-builder/src/main/kotlin/ru/avito/image_builder/Main.kt
+++ b/ci/docker/image-builder/src/main/kotlin/ru/avito/image_builder/Main.kt
@@ -2,6 +2,7 @@ package ru.avito.image_builder
 
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ExperimentalCli
+import ru.avito.image_builder.internal.cli.BuildEmulator
 import ru.avito.image_builder.internal.cli.BuildImage
 import ru.avito.image_builder.internal.cli.PublishEmulator
 import ru.avito.image_builder.internal.cli.PublishImage
@@ -15,9 +16,10 @@ public object Main {
             programName = "image-builder",
         )
 
-        parser.subcommands(
+         parser.subcommands(
             BuildImage("build", "Build image"),
             PublishImage("publish", "Build and publish image"),
+            BuildEmulator("buildEmulator", "Build Android emulator image"),
             PublishEmulator("publishEmulator", "Build and publish Android emulator image")
         )
         parser.parse(sanitizeEmptyArgs(args))

--- a/ci/docker/image-builder/src/main/kotlin/ru/avito/image_builder/internal/cli/BuildEmulator.kt
+++ b/ci/docker/image-builder/src/main/kotlin/ru/avito/image_builder/internal/cli/BuildEmulator.kt
@@ -1,0 +1,35 @@
+package ru.avito.image_builder.internal.cli
+
+import kotlinx.cli.ArgType
+import kotlinx.cli.required
+import ru.avito.image_builder.internal.command.EmulatorImageBuilder
+import ru.avito.image_builder.internal.command.ImageTagger
+import ru.avito.image_builder.internal.docker.CliDocker
+import java.io.File
+
+internal class BuildEmulator(
+    name: String,
+    description: String,
+) : BuildImage(name, description) {
+
+    private val api: Int by option(
+        type = ArgType.Int,
+        description = "API version"
+    ).required()
+
+    override fun execute() {
+        val docker = CliDocker()
+
+        EmulatorImageBuilder(
+            docker = docker,
+            dockerfilePath = dockerfilePath,
+            buildDir = File(buildDir),
+            api = api,
+            registry = registry,
+            imageName = imageName,
+            artifactoryUrl = artifactoryUrl,
+            login = dockerHubLogin(docker),
+            tagger = ImageTagger(docker),
+        ).build()
+    }
+}

--- a/ci/docker/image-builder/src/main/kotlin/ru/avito/image_builder/internal/cli/BuildImage.kt
+++ b/ci/docker/image-builder/src/main/kotlin/ru/avito/image_builder/internal/cli/BuildImage.kt
@@ -42,15 +42,15 @@ internal open class BuildImage(
         description = "DockerHub password"
     )
 
-    protected val registry: String by option(
+    protected val registry: String? by option(
         type = ArgType.String,
         description = "Docker target registry"
-    ).required()
+    )
 
-    protected val artifactoryUrl: String by option(
+    protected val artifactoryUrl: String? by option(
         type = ArgType.String,
         description = "Internal artifactory url"
-    ).required()
+    )
 
     protected val imageName: String by option(
         type = ArgType.String,

--- a/ci/docker/image-builder/src/main/kotlin/ru/avito/image_builder/internal/cli/PublishImage.kt
+++ b/ci/docker/image-builder/src/main/kotlin/ru/avito/image_builder/internal/cli/PublishImage.kt
@@ -1,7 +1,6 @@
 package ru.avito.image_builder.internal.cli
 
 import kotlinx.cli.ArgType
-import kotlinx.cli.ExperimentalCli
 import kotlinx.cli.required
 import ru.avito.image_builder.internal.command.ImagePublisher
 import ru.avito.image_builder.internal.command.ImageTagger
@@ -11,7 +10,6 @@ import ru.avito.image_builder.internal.docker.CliDocker
 import ru.avito.image_builder.internal.docker.RegistryCredentials
 import java.io.File
 
-@OptIn(ExperimentalCli::class)
 internal class PublishImage(
     name: String,
     description: String


### PR DESCRIPTION
- build non-hermetic emulator without avito internal access
- extract BuildEmulator, only publishing was available
- script to simplify a process a bit