### PR TITLE
Properly fix text typing on Android 13

### DIFF
--- a/subprojects/android-test/ui-testing-core-app/src/main/kotlin/com/avito/android/ui/EditTextActivity.kt
+++ b/subprojects/android-test/ui-testing-core-app/src/main/kotlin/com/avito/android/ui/EditTextActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.telephony.PhoneNumberFormattingTextWatcher
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
+import java.util.Locale
 
 class EditTextActivity : AppCompatActivity() {
 
@@ -12,7 +13,7 @@ class EditTextActivity : AppCompatActivity() {
         setContentView(R.layout.activity_edittext)
 
         findViewById<EditText>(R.id.phone_number_edit_text1).addTextChangedListener(
-            PhoneNumberFormattingTextWatcher()
+            PhoneNumberFormattingTextWatcher(Locale.US.country)
         )
     }
 }

--- a/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/element/field/actions/TypeText.kt
+++ b/subprojects/android-test/ui-testing-core/src/main/kotlin/com/avito/android/test/element/field/actions/TypeText.kt
@@ -72,18 +72,17 @@ internal class TypeText(private val stringToBeTyped: String) : ViewAction {
     private fun writeText(uiController: UiController, editText: EditText) {
         HiddenApiOpener.ensureUnseal()
 
-        // TODO replace 33 by Build.VERSION_CODES.TIRAMISU when compileSdk = 33
-        val inputFieldName = if (Build.VERSION.SDK_INT >= 33) {
-            "mFallbackInputConnection"
-        } else {
-            "mIInputContext"
-        }
-
         val context = (
             ApplicationProvider.getApplicationContext<Application>()
                 .getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            )
-            .getFieldByReflectionWithAnyField(inputFieldName)
+            ).run {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    getFieldByReflectionWithAnyField("mFallbackInputConnection")
+                        .getFieldByReflectionWithAnyField("mInputConnection")
+                } else {
+                    getFieldByReflectionWithAnyField("mIInputContext")
+                }
+            }
 
         var textChangedAtLeastOnce = false
         val textWatcher = object : SimpleTextWatcher() {


### PR DESCRIPTION
To properly fix issue #1425 we need to go deeper into the wrapper to obtain an input connection.
Also added a small fix to PhoneNumberFormattingTextWatcher - this will allow related test to pass on any device, not just that configured with a US locale.

Tested and confirmed on real Pixel 6a A13 device.